### PR TITLE
Add Liquid Glass Volume Visualization HUD

### DIFF
--- a/SonosVolumeController/Sources/SonosController.swift
+++ b/SonosVolumeController/Sources/SonosController.swift
@@ -346,6 +346,11 @@ class SonosController: @unchecked Sendable {
             let newVolume = max(0, min(100, currentVolume + delta))
             print("   📊 \(currentVolume) → \(newVolume)")
             self.sendSonosCommand(to: targetDevice, action: "SetVolume", arguments: ["DesiredVolume": String(newVolume)])
+
+            // Show HUD with new volume
+            Task { @MainActor in
+                VolumeHUD.shared.show(speaker: device.name, volume: newVolume)
+            }
         }
     }
 

--- a/SonosVolumeController/Sources/VolumeHUD.swift
+++ b/SonosVolumeController/Sources/VolumeHUD.swift
@@ -1,0 +1,159 @@
+import Cocoa
+
+@MainActor
+class VolumeHUD {
+    private var panel: NSPanel?
+    private var dismissTimer: Timer?
+    private var volumeLabel: NSTextField?
+    private var progressFillView: NSView?
+    private var speakerLabel: NSTextField?
+
+    static let shared = VolumeHUD()
+
+    private init() {}
+
+    func show(speaker: String, volume: Int) {
+        // Cancel any existing timer
+        dismissTimer?.invalidate()
+
+        // If panel exists, update it; otherwise create new one
+        if let existingPanel = panel, existingPanel.isVisible {
+            updateContent(speaker: speaker, volume: volume)
+        } else {
+            createPanel(speaker: speaker, volume: volume)
+        }
+
+        // Show with fade-in animation
+        panel?.alphaValue = 0
+        panel?.orderFront(nil)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.2
+            panel?.animator().alphaValue = 1.0
+        }
+
+        // Auto-dismiss after 1.5 seconds
+        dismissTimer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.hide()
+            }
+        }
+    }
+
+    private func hide() {
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.3
+            panel?.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            Task { @MainActor in
+                self?.panel?.orderOut(nil)
+            }
+        })
+    }
+
+    private func createPanel(speaker: String, volume: Int) {
+        // Panel dimensions - taller for better spacing
+        let width: CGFloat = 280
+        let height: CGFloat = 160
+
+        // Center on screen
+        guard let screen = NSScreen.main else { return }
+        let screenRect = screen.frame
+        let x = (screenRect.width - width) / 2
+        let y = (screenRect.height - height) / 2
+        let rect = NSRect(x: x, y: y, width: width, height: height)
+
+        // Create panel with HUD style
+        panel = NSPanel(
+            contentRect: rect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        guard let panel = panel else { return }
+
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.level = .popUpMenu
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        // Create visual effect view for Liquid Glass effect
+        let visualEffect = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+        visualEffect.material = .hudWindow
+        visualEffect.state = .active
+        visualEffect.blendingMode = .behindWindow
+        visualEffect.wantsLayer = true
+        visualEffect.layer?.cornerRadius = 20
+
+        // Create content container
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+
+        // Speaker icon (SF Symbol) - from bottom: 104pt
+        let iconView = NSImageView(frame: NSRect(x: (width - 44) / 2, y: 104, width: 44, height: 44))
+        if let speakerImage = NSImage(systemSymbolName: "hifispeaker.fill", accessibilityDescription: "Speaker") {
+            iconView.image = speakerImage
+            iconView.contentTintColor = .white
+            iconView.imageScaling = .scaleProportionallyUpOrDown
+        }
+        contentView.addSubview(iconView)
+
+        // Speaker name label - from bottom: 78pt
+        let nameLabel = NSTextField(labelWithString: speaker)
+        nameLabel.frame = NSRect(x: 20, y: 78, width: width - 40, height: 20)
+        nameLabel.alignment = .center
+        nameLabel.font = .systemFont(ofSize: 15, weight: .medium)
+        nameLabel.textColor = .white
+        contentView.addSubview(nameLabel)
+        speakerLabel = nameLabel
+
+        // Volume percentage label - from bottom: 38pt
+        let volLabel = NSTextField(labelWithString: "\(volume)%")
+        volLabel.frame = NSRect(x: 20, y: 38, width: width - 40, height: 30)
+        volLabel.alignment = .center
+        volLabel.font = .systemFont(ofSize: 28, weight: .semibold)
+        volLabel.textColor = .white
+        contentView.addSubview(volLabel)
+        volumeLabel = volLabel
+
+        // Progress bar background - from bottom: 18pt
+        let progressBg = NSView(frame: NSRect(x: 30, y: 18, width: width - 60, height: 8))
+        progressBg.wantsLayer = true
+        progressBg.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.3).cgColor
+        progressBg.layer?.cornerRadius = 4
+        contentView.addSubview(progressBg)
+
+        // Progress bar fill - from bottom: 18pt
+        let progressWidth = (width - 60) * CGFloat(volume) / 100.0
+        let progressFill = NSView(frame: NSRect(x: 30, y: 18, width: progressWidth, height: 8))
+        progressFill.wantsLayer = true
+        progressFill.layer?.backgroundColor = NSColor.white.cgColor
+        progressFill.layer?.cornerRadius = 4
+        contentView.addSubview(progressFill)
+        progressFillView = progressFill
+
+        visualEffect.addSubview(contentView)
+        panel.contentView = visualEffect
+    }
+
+    private func updateContent(speaker: String, volume: Int) {
+        // Update speaker name
+        speakerLabel?.stringValue = speaker
+
+        // Update volume label
+        volumeLabel?.stringValue = "\(volume)%"
+
+        // Update progress bar with animation
+        if let progressFill = progressFillView {
+            let panelWidth: CGFloat = 280
+            let newWidth = (panelWidth - 60) * CGFloat(volume) / 100.0
+
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.2
+                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                progressFill.animator().setFrameSize(NSSize(width: newWidth, height: 8))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds on-screen volume feedback overlay using macOS Tahoe 26.0's Liquid Glass design language.

### Key Features

- **Liquid Glass Styling**: NSVisualEffectView with .hudWindow material for native translucent appearance
- **Visual Feedback**: Displays speaker name, volume percentage, and animated progress bar
- **Smooth Animations**: 0.2s fade-in, 0.3s fade-out, animated progress bar updates
- **Auto-dismiss**: Disappears after 1.5 seconds
- **Proper Spacing**: 280×160pt panel with balanced vertical layout
- **Main Actor Safety**: Properly isolated for Swift 6 concurrency

## Implementation

**VolumeHUD.swift** (NEW)
- Singleton pattern with `@MainActor` isolation
- Creates borderless, non-activating NSPanel at `.popUpMenu` level
- Reuses existing panel for performance
- SF Symbol speaker icon (hifispeaker.fill)
- White text/icons on translucent Liquid Glass background
- Rounded corners (20pt radius)

**SonosController.swift** 
- Integrated HUD display in `changeVolume()` method
- Shows HUD after successful volume change
- Uses Task wrapper for main actor isolation

## Technical Details

- Collection behaviors: `.canJoinAllSpaces`, `.fullScreenAuxiliary`
- Centered on main screen
- Timer-based auto-dismiss with proper cleanup
- Progress bar animates width changes with ease-in-ease-out timing

## Testing

Tested on macOS 26.0 (Tahoe) with:
- F11/F12 volume controls
- Multiple volume adjustments in sequence
- HUD reuse and update behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)