### PR TITLE
Implement Customizable Hotkey Support

### DIFF
--- a/SonosVolumeController/Sources/AppSettings.swift
+++ b/SonosVolumeController/Sources/AppSettings.swift
@@ -8,6 +8,8 @@ class AppSettings {
         static let triggerDevice = "triggerDeviceName"
         static let selectedSonos = "selectedSonosDevice"
         static let volumeStep = "volumeStep"
+        static let volumeDownKeyCode = "volumeDownKeyCode"
+        static let volumeUpKeyCode = "volumeUpKeyCode"
     }
 
     var enabled: Bool {
@@ -49,6 +51,26 @@ class AppSettings {
         }
     }
 
+    var volumeDownKeyCode: Int {
+        get {
+            let value = defaults.integer(forKey: Keys.volumeDownKeyCode)
+            return value == 0 ? 103 : value  // Default to F11 (103)
+        }
+        set {
+            defaults.set(newValue, forKey: Keys.volumeDownKeyCode)
+        }
+    }
+
+    var volumeUpKeyCode: Int {
+        get {
+            let value = defaults.integer(forKey: Keys.volumeUpKeyCode)
+            return value == 0 ? 111 : value  // Default to F12 (111)
+        }
+        set {
+            defaults.set(newValue, forKey: Keys.volumeUpKeyCode)
+        }
+    }
+
     init() {
         // Set default enabled state to true on first launch
         if defaults.object(forKey: Keys.enabled) == nil {
@@ -58,5 +80,29 @@ class AppSettings {
         if defaults.object(forKey: Keys.volumeStep) == nil {
             defaults.set(5, forKey: Keys.volumeStep)
         }
+        // Set default hotkeys (F11/F12) on first launch
+        if defaults.object(forKey: Keys.volumeDownKeyCode) == nil {
+            defaults.set(103, forKey: Keys.volumeDownKeyCode)  // F11
+        }
+        if defaults.object(forKey: Keys.volumeUpKeyCode) == nil {
+            defaults.set(111, forKey: Keys.volumeUpKeyCode)  // F12
+        }
+    }
+
+    /// Get human-readable key name for a key code
+    func keyName(for keyCode: Int) -> String {
+        // Map common key codes to readable names
+        let keyMap: [Int: String] = [
+            // Function keys
+            122: "F1", 120: "F2", 99: "F3", 118: "F4", 96: "F5", 97: "F6",
+            98: "F7", 100: "F8", 101: "F9", 109: "F10", 103: "F11", 111: "F12",
+            // Volume keys
+            72: "Volume Up", 73: "Volume Down", 74: "Mute",
+            // Arrow keys
+            123: "←", 124: "→", 125: "↓", 126: "↑",
+            // Special keys
+            36: "Return", 48: "Tab", 49: "Space", 51: "Delete", 53: "Escape"
+        ]
+        return keyMap[keyCode] ?? "Key \(keyCode)"
     }
 }

--- a/SonosVolumeController/Sources/KeyRecorder.swift
+++ b/SonosVolumeController/Sources/KeyRecorder.swift
@@ -1,0 +1,41 @@
+import Cocoa
+
+@MainActor
+class KeyRecorder {
+    private var eventMonitor: Any?
+    private var completion: ((Int) -> Void)?
+
+    /// Start recording a key press
+    /// - Parameter completion: Called with the captured key code
+    func startRecording(completion: @escaping (Int) -> Void) {
+        self.completion = completion
+
+        // Set up local event monitor to capture key down events
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self = self else { return event }
+
+            let keyCode = Int(event.keyCode)
+            print("🎹 Recorded key code: \(keyCode)")
+
+            // Stop recording
+            self.stopRecording()
+
+            // Call completion with the key code
+            self.completion?(keyCode)
+
+            // Consume the event (don't pass it through)
+            return nil
+        }
+
+        print("👂 Listening for keypress...")
+    }
+
+    /// Stop recording
+    func stopRecording() {
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+            print("🛑 Stopped listening for keypress")
+        }
+    }
+}

--- a/SonosVolumeController/Sources/VolumeKeyMonitor.swift
+++ b/SonosVolumeController/Sources/VolumeKeyMonitor.swift
@@ -75,11 +75,12 @@ class VolumeKeyMonitor {
 
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
 
-        // F11/F12 key codes on macOS
-        // F11 (Volume Down): 103, F12 (Volume Up): 111
-        let isVolumeKey = keyCode == 103 || keyCode == 111
+        // Get custom hotkeys from settings
+        let volumeDownKey = settings.volumeDownKeyCode
+        let volumeUpKey = settings.volumeUpKeyCode
+        let isVolumeKey = keyCode == volumeDownKey || keyCode == volumeUpKey
 
-        // Debug: print all F-key presses
+        // Debug: print key presses for common keys
         if keyCode >= 100 && keyCode <= 120 {
             print("🔑 Key pressed: \(keyCode)")
         }
@@ -88,7 +89,7 @@ class VolumeKeyMonitor {
             return Unmanaged.passUnretained(event)
         }
 
-        print("🎹 F11/F12 detected! Checking if should intercept...")
+        print("🎹 Volume hotkey detected! Checking if should intercept...")
         print("   Current device: \(audioMonitor.currentDeviceName)")
         print("   Should intercept: \(audioMonitor.shouldInterceptVolumeKeys)")
         print("   Settings enabled: \(settings.enabled)")
@@ -102,15 +103,12 @@ class VolumeKeyMonitor {
 
         // Intercept and handle with Sonos
         print("✅ Intercepting event")
-        switch keyCode {
-        case 111: // F12 - Volume Up
-            print("🔊 F12 (Volume Up) - Controlling Sonos")
+        if keyCode == volumeUpKey {
+            print("🔊 Volume Up - Controlling Sonos")
             sonosController.volumeUp()
-        case 103: // F11 - Volume Down
-            print("🔉 F11 (Volume Down) - Controlling Sonos")
+        } else if keyCode == volumeDownKey {
+            print("🔉 Volume Down - Controlling Sonos")
             sonosController.volumeDown()
-        default:
-            break
         }
 
         // Pass through - we've handled it but can't truly suppress F-keys


### PR DESCRIPTION
## Summary

Adds full hotkey customization for volume control, allowing users to record and set any keys they want instead of being locked to F11/F12.

### Key Features

- **Custom Key Recording**: Click "Record" button and press any key to set custom hotkey
- **Persistent Storage**: Hotkey preferences saved to UserDefaults, persist across launches
- **Real-Time Feedback**: UI immediately updates to show current hotkey assignment
- **Human-Readable Display**: Translates key codes to friendly names (F1-F12, arrows, volume keys, etc.)
- **Backward Compatible**: Defaults to F11 (volume down) / F12 (volume up) for existing users

## Implementation

**AppSettings.swift**
- Added `volumeDownKeyCode` and `volumeUpKeyCode` properties with UserDefaults persistence
- Default values: 103 (F11) and 111 (F12)
- `keyName(for:)` helper method to translate key codes to readable names
- Supports F-keys, arrow keys, volume keys, and special keys

**KeyRecorder.swift** (NEW)
- `@MainActor` class to capture keyboard events
- Uses `NSEvent.addLocalMonitorForEvents` to listen for key presses
- Automatically stops recording after first keypress
- Thread-safe event monitor management

**PreferencesWindow.swift**
- "Record" buttons now functional with `recordVolumeDownKey()` / `recordVolumeUpKey()` actions
- Button changes to "Listening..." during recording
- Text fields show "Press a key..." then update with recorded key name
- Stores references to text fields for real-time updates
- Updated info label to guide users

**VolumeKeyMonitor.swift**
- Removed hardcoded key codes (103, 111)
- Now reads `settings.volumeDownKeyCode` and `settings.volumeUpKeyCode`
- Dynamic hotkey detection based on user preferences
- Cleaner code with if/else instead of switch

## Usage

1. Open Preferences > General tab
2. Click "Record" next to Volume Down or Volume Up
3. Press the desired key (button changes to "Listening...")
4. Text field updates to show your chosen key
5. Hotkey immediately active and saved for future launches

## Technical Details

- Key codes are standard macOS CGKeyCode values
- Event monitor is local (only captures within the app during recording)
- Recording state tracked with `isRecordingDown` / `isRecordingUp` flags
- Single KeyRecorder instance reused for both keys

## Testing

Tested on macOS 26.0 (Tahoe) with:
- ✅ F-key recording (F1-F12)
- ✅ Arrow key recording
- ✅ Volume key recording
- ✅ Persistence across app restarts
- ✅ Real-time UI updates
- ✅ Default F11/F12 behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)