### PR TITLE
Fix stereo pair/group volume control with topology caching

### DIFF
--- a/SonosVolumeController/Sources/MenuBarContentView.swift
+++ b/SonosVolumeController/Sources/MenuBarContentView.swift
@@ -479,7 +479,7 @@ class MenuBarContentViewController: NSViewController {
     }
 
     @objc private func refreshDevices() {
-        appDelegate?.sonosController.discoverDevices()
+        appDelegate?.sonosController.discoverDevices(forceRefreshTopology: true)
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             self.refresh()
         }

--- a/SonosVolumeController/Sources/PreferencesWindow.swift
+++ b/SonosVolumeController/Sources/PreferencesWindow.swift
@@ -396,14 +396,14 @@ class PreferencesWindow: NSObject, NSWindowDelegate {
     }
 
     @objc private func refreshSonos(_ sender: NSButton) {
-        print("Refreshing Sonos devices...")
-        appDelegate?.sonosController.discoverDevices()
+        print("Refreshing Sonos devices and topology...")
+        appDelegate?.sonosController.discoverDevices(forceRefreshTopology: true)
 
         // Refresh UI after a delay
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             // For now, just show a message that devices were refreshed
             // In a proper implementation, we'd update the dropdown in place
-            print("Sonos devices refreshed - please reopen preferences to see updates")
+            print("Sonos devices and topology refreshed - please reopen preferences to see updates")
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the bug where volume control only affected one speaker in stereo pairs by implementing proper coordinator routing with efficient topology caching.

### 🐛 Bug Fixed
- Volume commands for stereo pairs/groups now control all speakers correctly
- Previously only one speaker in a pair would change volume

### ⚡ Performance Optimization
- Added in-memory topology caching to reduce network calls
- Topology fetched once on startup, cached for entire session
- Manual refresh available through Preferences and menu bar

## Implementation Details

### Topology Caching
- `topologyCache: [String: String]` maps device UUIDs to coordinator UUIDs
- Cache persists during app session for optimal performance
- `hasLoadedTopology` flag prevents redundant network calls

### Coordinator Routing
- All volume commands properly route through group coordinators
- Existing coordinator detection logic enhanced with caching
- Stereo pairs and grouped speakers stay in perfect sync

### Cache Management
- `discoverDevices(forceRefreshTopology: Bool)` parameter for cache control
- Manual refresh in Preferences and menu clears cache
- Automatic cache population on first device discovery

## Testing

Tested with:
- ✅ Stereo pairs - both speakers now change volume together
- ✅ Cache persistence - topology loads once, uses cache thereafter
- ✅ Manual refresh - clears cache and fetches fresh topology
- ✅ App restart - cache properly cleared on new session

## Files Changed
- `SonosController.swift` - Added caching logic and force refresh parameter
- `PreferencesWindow.swift` - Updated refresh to clear cache
- `MenuBarContentView.swift` - Updated refresh to clear cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)