### PR TITLE
Add support for hotkey combinations with modifier keys

### DIFF
--- a/SonosVolumeController/Sources/AppSettings.swift
+++ b/SonosVolumeController/Sources/AppSettings.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Cocoa
 
 class AppSettings {
     private let defaults = UserDefaults.standard
@@ -10,6 +11,8 @@ class AppSettings {
         static let volumeStep = "volumeStep"
         static let volumeDownKeyCode = "volumeDownKeyCode"
         static let volumeUpKeyCode = "volumeUpKeyCode"
+        static let volumeDownModifiers = "volumeDownModifiers"
+        static let volumeUpModifiers = "volumeUpModifiers"
     }
 
     var enabled: Bool {
@@ -71,6 +74,24 @@ class AppSettings {
         }
     }
 
+    var volumeDownModifiers: UInt {
+        get {
+            UInt(defaults.integer(forKey: Keys.volumeDownModifiers))
+        }
+        set {
+            defaults.set(Int(newValue), forKey: Keys.volumeDownModifiers)
+        }
+    }
+
+    var volumeUpModifiers: UInt {
+        get {
+            UInt(defaults.integer(forKey: Keys.volumeUpModifiers))
+        }
+        set {
+            defaults.set(Int(newValue), forKey: Keys.volumeUpModifiers)
+        }
+    }
+
     init() {
         // Set default enabled state to true on first launch
         if defaults.object(forKey: Keys.enabled) == nil {
@@ -101,8 +122,35 @@ class AppSettings {
             // Arrow keys
             123: "←", 124: "→", 125: "↓", 126: "↑",
             // Special keys
-            36: "Return", 48: "Tab", 49: "Space", 51: "Delete", 53: "Escape"
+            36: "Return", 48: "Tab", 49: "Space", 51: "Delete", 53: "Escape",
+            // Number keys
+            18: "1", 19: "2", 20: "3", 21: "4", 23: "5",
+            22: "6", 26: "7", 28: "8", 25: "9", 29: "0"
         ]
         return keyMap[keyCode] ?? "Key \(keyCode)"
+    }
+
+    /// Get human-readable key combination string
+    func keyComboName(for keyCode: Int, modifiers: UInt) -> String {
+        var parts: [String] = []
+
+        // Add modifier symbols
+        if modifiers & NSEvent.ModifierFlags.control.rawValue != 0 {
+            parts.append("⌃")
+        }
+        if modifiers & NSEvent.ModifierFlags.option.rawValue != 0 {
+            parts.append("⌥")
+        }
+        if modifiers & NSEvent.ModifierFlags.shift.rawValue != 0 {
+            parts.append("⇧")
+        }
+        if modifiers & NSEvent.ModifierFlags.command.rawValue != 0 {
+            parts.append("⌘")
+        }
+
+        // Add key name
+        parts.append(keyName(for: keyCode))
+
+        return parts.joined()
     }
 }

--- a/SonosVolumeController/Sources/KeyRecorder.swift
+++ b/SonosVolumeController/Sources/KeyRecorder.swift
@@ -3,11 +3,11 @@ import Cocoa
 @MainActor
 class KeyRecorder {
     private var eventMonitor: Any?
-    private var completion: ((Int) -> Void)?
+    private var completion: ((Int, UInt) -> Void)?
 
-    /// Start recording a key press
-    /// - Parameter completion: Called with the captured key code
-    func startRecording(completion: @escaping (Int) -> Void) {
+    /// Start recording a key press with modifiers
+    /// - Parameter completion: Called with the captured key code and modifier flags
+    func startRecording(completion: @escaping (Int, UInt) -> Void) {
         self.completion = completion
 
         // Set up local event monitor to capture key down events
@@ -15,13 +15,21 @@ class KeyRecorder {
             guard let self = self else { return event }
 
             let keyCode = Int(event.keyCode)
-            print("🎹 Recorded key code: \(keyCode)")
+            let modifierFlags = event.modifierFlags.rawValue
+
+            // Extract only relevant modifier flags (Command, Option, Shift, Control)
+            let relevantFlags = modifierFlags & (NSEvent.ModifierFlags.command.rawValue |
+                                                 NSEvent.ModifierFlags.option.rawValue |
+                                                 NSEvent.ModifierFlags.shift.rawValue |
+                                                 NSEvent.ModifierFlags.control.rawValue)
+
+            print("🎹 Recorded key code: \(keyCode), modifiers: \(relevantFlags)")
 
             // Stop recording
             self.stopRecording()
 
-            // Call completion with the key code
-            self.completion?(keyCode)
+            // Call completion with the key code and modifiers
+            self.completion?(keyCode, relevantFlags)
 
             // Consume the event (don't pass it through)
             return nil

--- a/SonosVolumeController/Sources/PreferencesWindow.swift
+++ b/SonosVolumeController/Sources/PreferencesWindow.swift
@@ -133,8 +133,9 @@ class PreferencesWindow: NSObject, NSWindowDelegate {
         view.addSubview(downLabel)
 
         let downKeyCode = appDelegate?.settings.volumeDownKeyCode ?? 103
-        let downKeyName = appDelegate?.settings.keyName(for: downKeyCode) ?? "F11"
-        let downText = createTextField(downKeyName, frame: NSRect(x: 140, y: yPos, width: 150, height: 24))
+        let downModifiers = appDelegate?.settings.volumeDownModifiers ?? 0
+        let downKeyCombo = appDelegate?.settings.keyComboName(for: downKeyCode, modifiers: downModifiers) ?? "F11"
+        let downText = createTextField(downKeyCombo, frame: NSRect(x: 140, y: yPos, width: 150, height: 24))
         downText.alignment = .center
         view.addSubview(downText)
         volumeDownTextField = downText
@@ -153,8 +154,9 @@ class PreferencesWindow: NSObject, NSWindowDelegate {
         view.addSubview(upLabel)
 
         let upKeyCode = appDelegate?.settings.volumeUpKeyCode ?? 111
-        let upKeyName = appDelegate?.settings.keyName(for: upKeyCode) ?? "F12"
-        let upText = createTextField(upKeyName, frame: NSRect(x: 140, y: yPos, width: 150, height: 24))
+        let upModifiers = appDelegate?.settings.volumeUpModifiers ?? 0
+        let upKeyCombo = appDelegate?.settings.keyComboName(for: upKeyCode, modifiers: upModifiers) ?? "F12"
+        let upText = createTextField(upKeyCombo, frame: NSRect(x: 140, y: yPos, width: 150, height: 24))
         upText.alignment = .center
         view.addSubview(upText)
         volumeUpTextField = upText
@@ -414,7 +416,7 @@ class PreferencesWindow: NSObject, NSWindowDelegate {
         sender.title = "Listening..."
         volumeDownTextField?.stringValue = "Press a key..."
 
-        keyRecorder.startRecording { [weak self] keyCode in
+        keyRecorder.startRecording { [weak self] keyCode, modifiers in
             guard let self = self else { return }
 
             self.isRecordingDown = false
@@ -422,12 +424,13 @@ class PreferencesWindow: NSObject, NSWindowDelegate {
 
             // Update settings
             self.appDelegate?.settings.volumeDownKeyCode = keyCode
+            self.appDelegate?.settings.volumeDownModifiers = modifiers
 
             // Update display
-            let keyName = self.appDelegate?.settings.keyName(for: keyCode) ?? "Key \(keyCode)"
-            self.volumeDownTextField?.stringValue = keyName
+            let keyCombo = self.appDelegate?.settings.keyComboName(for: keyCode, modifiers: modifiers) ?? "Key \(keyCode)"
+            self.volumeDownTextField?.stringValue = keyCombo
 
-            print("✅ Volume down key set to: \(keyName) (code: \(keyCode))")
+            print("✅ Volume down key set to: \(keyCombo) (code: \(keyCode), modifiers: \(modifiers))")
         }
     }
 
@@ -438,7 +441,7 @@ class PreferencesWindow: NSObject, NSWindowDelegate {
         sender.title = "Listening..."
         volumeUpTextField?.stringValue = "Press a key..."
 
-        keyRecorder.startRecording { [weak self] keyCode in
+        keyRecorder.startRecording { [weak self] keyCode, modifiers in
             guard let self = self else { return }
 
             self.isRecordingUp = false
@@ -446,12 +449,13 @@ class PreferencesWindow: NSObject, NSWindowDelegate {
 
             // Update settings
             self.appDelegate?.settings.volumeUpKeyCode = keyCode
+            self.appDelegate?.settings.volumeUpModifiers = modifiers
 
             // Update display
-            let keyName = self.appDelegate?.settings.keyName(for: keyCode) ?? "Key \(keyCode)"
-            self.volumeUpTextField?.stringValue = keyName
+            let keyCombo = self.appDelegate?.settings.keyComboName(for: keyCode, modifiers: modifiers) ?? "Key \(keyCode)"
+            self.volumeUpTextField?.stringValue = keyCombo
 
-            print("✅ Volume up key set to: \(keyName) (code: \(keyCode))")
+            print("✅ Volume up key set to: \(keyCombo) (code: \(keyCode), modifiers: \(modifiers))")
         }
     }
 

--- a/SonosVolumeController/Sources/VolumeKeyMonitor.swift
+++ b/SonosVolumeController/Sources/VolumeKeyMonitor.swift
@@ -74,11 +74,24 @@ class VolumeKeyMonitor {
         }
 
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        let eventFlags = event.flags
+
+        // Extract relevant modifier flags from event
+        let relevantEventFlags = eventFlags.rawValue & (CGEventFlags.maskCommand.rawValue |
+                                                         CGEventFlags.maskAlternate.rawValue |
+                                                         CGEventFlags.maskShift.rawValue |
+                                                         CGEventFlags.maskControl.rawValue)
 
         // Get custom hotkeys from settings
         let volumeDownKey = settings.volumeDownKeyCode
         let volumeUpKey = settings.volumeUpKeyCode
-        let isVolumeKey = keyCode == volumeDownKey || keyCode == volumeUpKey
+        let volumeDownModifiers = settings.volumeDownModifiers
+        let volumeUpModifiers = settings.volumeUpModifiers
+
+        // Check if this matches our volume hotkeys (key code + modifiers)
+        let isVolumeDownKey = (keyCode == volumeDownKey) && (relevantEventFlags == volumeDownModifiers)
+        let isVolumeUpKey = (keyCode == volumeUpKey) && (relevantEventFlags == volumeUpModifiers)
+        let isVolumeKey = isVolumeDownKey || isVolumeUpKey
 
         // Debug: print key presses for common keys
         if keyCode >= 100 && keyCode <= 120 {
@@ -103,10 +116,10 @@ class VolumeKeyMonitor {
 
         // Intercept and handle with Sonos
         print("✅ Intercepting event")
-        if keyCode == volumeUpKey {
+        if isVolumeUpKey {
             print("🔊 Volume Up - Controlling Sonos")
             sonosController.volumeUp()
-        } else if keyCode == volumeDownKey {
+        } else if isVolumeDownKey {
             print("🔉 Volume Down - Controlling Sonos")
             sonosController.volumeDown()
         }


### PR DESCRIPTION
## Summary

Fixes the bug where hotkey recording only captured the base key and ignored modifier keys (Command, Shift, Option, Control).

### 🐛 Bug Fixed
- Hotkey recording now captures full key combinations including modifiers
- Users can now set hotkeys like ⌘9, ⇧F11, ⌃⌥F12, etc.
- Previously only single keys (without modifiers) were supported

## Implementation Details

### KeyRecorder.swift
- Updated callback signature to `(Int, UInt) -> Void` for keyCode + modifiers
- Extracts only relevant modifier flags (Command, Option, Shift, Control)
- Filters out system flags like CapsLock, NumLock, Function key

### AppSettings.swift
- Added `volumeDownModifiers` and `volumeUpModifiers` properties
- Persistent storage via UserDefaults
- New `keyComboName()` formats combinations with macOS symbols:
  - ⌃ Control
  - ⌥ Option
  - ⇧ Shift
  - ⌘ Command
- Added number key mappings (1-9, 0)

### PreferencesWindow.swift
- Updated recording callbacks to receive and store modifiers
- Display shows full combinations (e.g., "⌘9" instead of just "9")
- Initial UI loads and displays saved combinations correctly

### VolumeKeyMonitor.swift
- Checks both keyCode AND modifierFlags for hotkey matches
- Extracts relevant flags from CGEvent using matching mask
- Only triggers volume control when FULL combination matches

## Technical Details

Uses NSEvent.ModifierFlags for recording and CGEventFlags for monitoring:
- **Command**: `0x100000`
- **Option**: `0x80000`  
- **Shift**: `0x20000`
- **Control**: `0x40000`

Backward compatible - existing F11/F12 keys work without modifiers (0x0 flags).

## Testing

Tested with:
- ✅ Build completes successfully
- ✅ Single keys still work (F11, F12)
- ✅ Modifier combinations can be recorded
- ✅ Display shows proper symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)