### PR TITLE
UI Enhancements: Improved Menu Bar Popout Layout and Spacing

### DIFF
--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -7,5 +7,6 @@
 - [ ] App Store submission
 
 ## Future Ideas
-- make it so i can group speakers easily, my default speaker as set in preferences should be the audio source when grouping other speakers 
-- BUG - fix custom keystroke, it isn't taking key combinations (ie i tried command+9 and it just took the key for "9")
+- ultrathink on this, make it so i can group speakers easily, my default speaker as set in preferences should be the audio source when grouping other speakers. make sure to lookup 2025 office sonos documentation 09
+- icon: we need to make the icon something better than S, can you make an SVG that looks like a sonos speaker? i have no idea what best practices are around this. avoid looking like the macos native volume control 
+- BUG, the slider in the UI only changes one of the speakers, we need the slider to follow the exact same logic as the hotkeys so that a speaker pair or whatnot is controlled not just one within a pair 


### PR DESCRIPTION
## Summary

Comprehensive UI improvements for the menu bar popout based on user feedback, focusing on cleaner layout, better spacing, and improved usability.

### Layout Changes
- ✅ **Removed refresh button** from popout (refresh functionality remains in Preferences)
- ✅ **Neutralized quit button** color (changed from red to gray)
- ✅ **Removed text labels** from Settings and Quit icons for cleaner look
- ✅ **Eliminated scrollbars** - no horizontal or vertical scroll in speaker list

### Sizing and Spacing
- ✅ **Increased popout height** from 540pt to 650pt
- ✅ **Expanded speaker list area** from 160pt to 310pt (fits all speakers)
- ✅ **Minimized spacing** above speaker list (removed scroll view content insets)
- ✅ **Better icon sizing** - 20pt icons with 44x44pt touch targets
- ✅ **Improved icon alignment** - 40pt horizontal spacing, both aligned vertically

### Speaker List
- ✅ **Smart sorting** - default speaker at top (labeled "Default"), rest alphabetically
- ✅ **Proper layout** - no unnecessary gaps or spacing

## Technical Details

**Files Changed:**
- `MenuBarContentView.swift` - Major layout refactoring
- `FEATURES.md` - Updated with new bugs and feature ideas

**Key Changes:**
- Removed `refreshDevices()` method and refresh button stack
- Changed quit button `contentTintColor` from `.systemRed` to `.secondaryLabelColor`
- Disabled scroll view scrollers and set `contentInsets` to zero
- Implemented speaker sorting in `populateSpeakers()` with coordinator priority
- Updated container height and scroll view constraints

## Testing

Tested on macOS 26.0 (Tahoe) with:
- Multiple speakers displaying correctly
- All spacing adjustments verified visually
- Icon sizes and alignment confirmed
- Speaker sorting working (default first, then alphabetical)

## Notes

User reported some other bugs that may or may not be related to this PR - ready to roll back if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)