### PR TITLE
Add proper .app bundle build with install support

### DIFF
--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -14,3 +14,6 @@
 - grouping speakers with default: ultrathink on this, make it so i can group speakers easily, my default speaker as set in preferences should be the audio source when grouping other speakers. make sure to lookup 2025 office sonos documentation 09
 - when the app first loads, and the default speaker is confirmed as part of the current topology, update the current volume to match the default speaker, if the default speaker is unavailable, leave blank
 - BUG sometimes there are missing speakers in the list and I don't know why, do we need a longer timeout? or multiple pings? 
+- BUG: when i refresh the speakers in the settings window it updates the options in the menu bar, but the settings drop down doesn't update.
+- Enhancement: when i load the app for the first time the user should be prompted to enable the required accessiblity settings so i don't have to dig for them 
+- Enhancement: when i try to change the volume but i am not connected to the set trigger audio device, i should see a notice that looks just like the volume changer that appears when i successfully do change the volume so that I know why it is not working 

--- a/SonosVolumeController/Resources/entitlements.plist
+++ b/SonosVolumeController/Resources/entitlements.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Enable hardened runtime -->
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<false/>
+
+	<!-- Allow network access for Sonos discovery -->
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+
+	<!-- Allow audio device access -->
+	<key>com.apple.security.device.audio-input</key>
+	<false/>
+
+	<!-- Disable library validation for better compatibility -->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<false/>
+
+	<!-- Allow JIT if needed (set to false for hardened runtime) -->
+	<key>com.apple.security.cs.allow-jit</key>
+	<false/>
+</dict>
+</plist>

--- a/SonosVolumeController/build-app.sh
+++ b/SonosVolumeController/build-app.sh
@@ -10,17 +10,96 @@ echo "🔨 Building Sonos Volume Controller.app..."
 rm -rf SonosVolumeController.app
 
 # Build with Swift Package Manager
+echo "📦 Compiling with Swift Package Manager..."
 swift build -c release
 
 # Create .app bundle structure
+echo "📁 Creating .app bundle structure..."
 mkdir -p SonosVolumeController.app/Contents/MacOS
 mkdir -p SonosVolumeController.app/Contents/Resources
 
 # Copy executable
+echo "📋 Copying executable..."
 cp .build/release/SonosVolumeController SonosVolumeController.app/Contents/MacOS/
 
 # Copy Info.plist
+echo "📋 Copying Info.plist..."
 cp Resources/Info.plist SonosVolumeController.app/Contents/Info.plist
 
+# Copy Resources folder (icons, etc.)
+echo "📋 Copying resources..."
+if [ -f Resources/SonosMenuBarIcon.svg ]; then
+    cp Resources/SonosMenuBarIcon.svg SonosVolumeController.app/Contents/Resources/
+fi
+
+# Code signing
+echo "🔐 Code signing..."
+SIGNING_IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | sed -E 's/.*"(.+)".*/\1/')
+
+if [ -n "$SIGNING_IDENTITY" ]; then
+    echo "✅ Found signing identity: $SIGNING_IDENTITY"
+    codesign --force --sign "$SIGNING_IDENTITY" \
+        --entitlements Resources/entitlements.plist \
+        --options runtime \
+        --timestamp \
+        SonosVolumeController.app/Contents/MacOS/SonosVolumeController
+
+    codesign --force --sign "$SIGNING_IDENTITY" \
+        --entitlements Resources/entitlements.plist \
+        --options runtime \
+        --timestamp \
+        --deep \
+        SonosVolumeController.app
+
+    echo "✅ App signed with Developer ID"
+else
+    echo "⚠️  No Developer ID found, using ad-hoc signing (works locally only)"
+    codesign --force --sign - SonosVolumeController.app
+fi
+
+# Verify signature
+echo "🔍 Verifying signature..."
+codesign -dv SonosVolumeController.app 2>&1 | head -5
+
+echo ""
 echo "✅ Build complete: SonosVolumeController.app"
-echo "Run with: open SonosVolumeController.app"
+echo ""
+
+# Optional: Install to /Applications
+if [ "$1" == "--install" ] || [ "$1" == "-i" ]; then
+    echo "📦 Installing to /Applications..."
+
+    # Kill running instance if it exists
+    if pgrep -x "SonosVolumeController" > /dev/null; then
+        echo "⚠️  Stopping running instance..."
+        pkill -x "SonosVolumeController"
+        sleep 1
+    fi
+
+    # Remove old version
+    if [ -d "/Applications/SonosVolumeController.app" ]; then
+        echo "🗑️  Removing old version..."
+        sudo rm -rf /Applications/SonosVolumeController.app
+    fi
+
+    # Copy new version
+    echo "📋 Copying to /Applications..."
+    sudo cp -R SonosVolumeController.app /Applications/
+
+    echo "✅ Installed to /Applications!"
+    echo ""
+    echo "🚀 Launching..."
+    open /Applications/SonosVolumeController.app
+    echo ""
+    echo "📌 To enable 'Run at Login':"
+    echo "   Click menu bar icon → Preferences → General → Run at Login"
+else
+    echo "📌 To install to /Applications (keeps development copy):"
+    echo "   ./build-app.sh --install"
+    echo ""
+    echo "📌 Or manually:"
+    echo "   sudo cp -R SonosVolumeController.app /Applications/"
+    echo "   open /Applications/SonosVolumeController.app"
+fi
+echo ""
+echo "💡 Tip: The app runs in your menu bar without showing in the Dock"


### PR DESCRIPTION
## Summary
- Add entitlements file for hardened runtime with network permissions for Sonos discovery
- Enhanced build script with automatic resource copying and code signing
- Add `--install` flag for one-command development workflow (copies to /Applications)
- Properly handles running instances during updates
- Update FEATURES.md with new enhancement ideas and bug notes

## Usage

```bash
# Build only
./build-app.sh

# Build and install to /Applications
./build-app.sh --install
```

The app now properly installs as a native macOS menu bar application that can run on login without terminal.

## Test plan
- [x] Build script successfully creates .app bundle
- [x] Resources (SVG icon) properly copied to bundle
- [x] Code signing works (ad-hoc for local dev)
- [x] `--install` flag copies to /Applications and launches
- [x] "Run at Login" feature works from /Applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)