### PR TITLE
Fix: Improve Sonos device discovery reliability and add loading UI

### DIFF
--- a/SonosVolumeController/DEVELOPMENT.md
+++ b/SonosVolumeController/DEVELOPMENT.md
@@ -1,0 +1,67 @@
+# Development Workflow
+
+## Quick Testing (Development)
+
+When making changes and testing, use `swift run`:
+
+```bash
+# Kill any running instance first
+pkill SonosVolumeController
+
+# Run your dev version
+swift run
+```
+
+This runs the app directly from your development directory without needing to build the .app bundle or install anywhere. Press `Ctrl+C` to stop it when done testing.
+
+**Benefits:**
+- Fast - no build/install step needed
+- Changes compile automatically
+- Easy to iterate quickly
+
+## Installing to /Applications (Production)
+
+When you're ready to use your changes as your daily driver app, install to /Applications:
+
+```bash
+./build-app.sh --install
+```
+
+This will:
+1. Build the .app bundle
+2. Kill any running instance
+3. Copy to /Applications
+4. Launch the installed version
+
+**You MUST install to /Applications if you want:**
+- App to run on login (the "Run at Login" feature)
+- App to run without the terminal
+- A permanent version that's not tied to development
+
+## Typical Development Cycle
+
+1. **Make code changes** in your editor
+2. **Test with `swift run`** - repeat as needed
+3. **Commit your changes** to git
+4. **Create/merge PR** when satisfied
+5. **Install to /Applications** when ready to use permanently: `./build-app.sh --install`
+
+## Note: You Cannot Run Both Versions Simultaneously
+
+The development version (via `swift run`) and installed version (in /Applications) will conflict because they both:
+- Create a menu bar icon
+- Listen for the same hotkeys
+- Monitor the same audio device
+- Control the same Sonos speakers
+
+Always kill one before running the other with `pkill SonosVolumeController`.
+
+## Building Without Installing
+
+If you just want to build the .app bundle without installing:
+
+```bash
+./build-app.sh
+```
+
+The .app will be created in your project directory as `SonosVolumeController.app`.


### PR DESCRIPTION
## Summary
- Improved SSDP discovery to reliably find all Sonos speakers on the network
- Added loading indicator to menu bar view during device discovery
- Added DEVELOPMENT.md with development workflow documentation

## Discovery Improvements
**Problem**: Some speakers were randomly missing from the discovered devices list

**Solution**:
- Increased MX from 1→3 seconds (gives devices more response time)
- Send 3 discovery packets instead of 1 (catches devices that miss first packet)
- Increased timeout from 3→5 seconds (allows more time for all responses)
- Added detailed logging for discovery debugging

## Loading UI
- Shows spinner with "Discovering speakers..." message during discovery
- Automatically displays on initial app launch when no devices found yet
- Shows when user clicks "Refresh Devices" in preferences
- Listens for `SonosDiscoveryStarted` and `SonosDevicesDiscovered` notifications

## Documentation
Added `DEVELOPMENT.md` with:
- How to use `swift run` for quick testing
- When to use `./build-app.sh --install` 
- Explanation of development vs installed versions
- Note that only one instance can run at a time

## Test plan
- [x] Code compiles successfully
- [x] Discovery improvements implemented (MX=3, 3 packets, 5s timeout)
- [x] Loading indicator shows on app launch
- [x] Loading indicator shows when refreshing devices
- [x] Loading indicator hides when discovery completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)