### PR TITLE
Feature: Sync volume slider with default speaker on app launch

### DIFF
--- a/SonosVolumeController/Sources/MenuBarContentView.swift
+++ b/SonosVolumeController/Sources/MenuBarContentView.swift
@@ -177,8 +177,8 @@ class MenuBarContentViewController: NSViewController {
         volumeSlider.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(volumeSlider)
 
-        // Fetch current volume from Sonos (will enable slider when loaded)
-        updateVolumeFromSonos()
+        // Volume will be fetched after device discovery completes (via notification)
+        // Don't fetch here as it would return default 50 before discovery finishes
 
         // Volume percentage label
         volumeLabel = NSTextField(labelWithString: "—")
@@ -591,7 +591,7 @@ class MenuBarContentViewController: NSViewController {
         speakerNameLabel.stringValue = appDelegate?.settings.selectedSonosDevice ?? "No Speaker"
         updateStatus()
         populateSpeakers()
-        updateVolumeFromSonos()
+        // Don't fetch volume here - it will be updated via notification after device selection
     }
 
     private func updateVolumeFromSonos() {

--- a/SonosVolumeController/Sources/main.swift
+++ b/SonosVolumeController/Sources/main.swift
@@ -93,6 +93,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 if !self.settings.selectedSonosDevice.isEmpty {
                     print("🎵 Auto-selecting default speaker (after topology loaded): \(self.settings.selectedSonosDevice)")
                     self.sonosController.selectDevice(name: self.settings.selectedSonosDevice)
+
+                    // Fetch and sync current volume from the selected speaker
+                    print("🔊 Fetching current volume from default speaker...")
+                    self.sonosController.getVolume { volume in
+                        print("🔊 Initial volume: \(volume)%")
+                        // Post notification to update UI
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(
+                                name: NSNotification.Name("SonosVolumeDidChange"),
+                                object: nil,
+                                userInfo: ["volume": volume]
+                            )
+                        }
+                    }
+                } else {
+                    print("⚠️ No default speaker configured")
                 }
 
                 print("✅ Sonos discovery and topology loaded")


### PR DESCRIPTION
## Summary
- Volume slider now syncs with the actual default speaker volume on app launch
- Previously showed generic 50% until user manually opened the menu bar
- Now accurately reflects current speaker volume immediately after discovery completes

## Implementation
After device discovery and topology loading:
1. Auto-select default speaker (existing behavior)
2. **NEW**: Fetch current volume from selected speaker
3. **NEW**: Post `SonosVolumeDidChange` notification to update UI
4. Volume slider and label automatically sync to actual speaker volume

## Behavior for Unavailable Speakers
- **No default configured**: Logs warning, volume stays at 50 (default state)
- **Default configured but not found**: `selectDevice` fails gracefully, `getVolume` returns 50
- **Default available**: Fetches and displays actual volume ✓

Existing error handling ensures graceful fallback in all cases.

## Test plan
- [x] Code compiles successfully
- [x] Volume fetch happens after speaker selection in initialization
- [x] Notification posted to update UI
- [x] Unavailable speaker cases handled gracefully by existing error handling

To test:
1. Set a default speaker in preferences
2. Quit and restart the app
3. Open menu bar popover immediately after launch
4. Volume slider should show actual speaker volume (not 50%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)