### PR TITLE
Enhancement: Show HUD notification when volume key pressed on wrong audio device

### DIFF
--- a/SonosVolumeController/CLAUDE.md
+++ b/SonosVolumeController/CLAUDE.md
@@ -1,0 +1,138 @@
+# Claude Collaboration Guide
+
+This document guides collaboration between Claude and the developer on the Sonos Volume Controller project.
+
+## Workflow
+
+### 1. Picking Next Task
+
+Review `FEATURES.md` and select from:
+- **Features**: Major new functionality
+- **Enhancements**: Improvements to existing features
+- **Bugs**: Issues that need fixing
+- **App Store Readiness**: Tasks for App Store submission
+
+Discuss with the user which task to tackle next.
+
+### 2. Starting Work
+
+1. **Create branch from main**: Use descriptive naming
+   - Features: `feature/descriptive-name`
+   - Enhancements: `enhancement/descriptive-name`
+   - Bugs: `bug/descriptive-name`
+
+2. **Plan mode**: Present implementation plan before coding
+
+3. **Track progress**: Use TodoWrite tool for multi-step tasks
+
+### 3. Completing Work
+
+1. **Test**: Build with `swift build -c release` or `swift run`
+
+2. **Commit**: Write clear commit message with emoji prefix
+   ```
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+   Co-Authored-By: Claude <noreply@anthropic.com>
+   ```
+
+3. **Create PR**: Use `gh pr create` with detailed description
+
+4. **Update FEATURES.md**:
+   - Move completed item from Features/Enhancements/Bugs to "Completed Improvements"
+   - Add PR number reference
+   - Commit update to the same branch
+
+### 4. After Merge
+
+User merges PR on GitHub, then locally:
+```bash
+git checkout main
+git pull
+```
+
+## Development Commands
+
+### Quick Testing
+```bash
+# Run directly without building .app
+swift run
+
+# Kill running instance first
+pkill SonosVolumeController && swift run
+```
+
+### Building & Installing
+```bash
+# Build only (creates .app in project directory)
+./build-app.sh
+
+# Build and install to /Applications
+./build-app.sh --install
+```
+
+### Git Workflow
+```bash
+# Create new branch
+git checkout main
+git pull
+git checkout -b feature/name
+
+# Commit changes
+git add .
+git commit -m "message"
+
+# Push and create PR
+git push -u origin feature/name
+gh pr create --title "Title" --body "Description"
+```
+
+## Project Architecture
+
+### Key Components
+
+- **main.swift**: App entry point, initialization
+- **VolumeKeyMonitor.swift**: Captures F11/F12 hotkeys via event tap
+- **AudioDeviceMonitor.swift**: Tracks current audio output device
+- **SonosController.swift**: Sonos device discovery and control
+- **VolumeHUD.swift**: On-screen volume display (Liquid Glass HUD)
+- **MenuBarContentView.swift**: Menu bar popover UI
+- **PreferencesWindow.swift**: Settings window
+
+### Important Patterns
+
+1. **Audio Device Trigger**: Only intercept volume keys when specific audio device is active
+2. **Topology Loading**: Must discover devices + load topology before selecting speaker
+3. **Stereo Pairs**: Query visible speaker (it controls both in pair)
+4. **@MainActor**: VolumeHUD and UI components require main actor isolation
+
+## Session Log
+
+### Session: 2025-09-29
+
+**Completed:**
+- ✅ PR #13: Settings dropdown updates when refreshing devices
+- ✅ PR #14: Improved device discovery reliability + loading indicator
+- ✅ PR #15: Volume slider syncs with default speaker on launch
+- ✅ PR #16: Wrong device HUD notification
+- ✅ Updated FEATURES.md organization
+- ✅ Created CLAUDE.md collaboration guide
+
+**Next Priorities:**
+1. Accessibility settings prompt on first launch (Enhancement)
+2. Speaker grouping functionality (Feature)
+
+**Notes:**
+- App is fully functional as native macOS menu bar app
+- `./build-app.sh --install` workflow is working well
+- Development workflow via `swift run` is smooth
+
+---
+
+## Tips for Future Sessions
+
+- Always check `FEATURES.md` at start of session
+- Use `swift run` for quick iteration during development
+- Only use `./build-app.sh --install` when ready to test installed behavior
+- Keep PRs focused on single feature/enhancement/bug
+- Update this log at end of significant sessions

--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -6,6 +6,15 @@
 - [ ] Sandboxing configuration
 - [ ] App Store submission
 
+## Features
+- **Speaker grouping functionality**: Make it easy to group speakers with the default speaker as the audio source. The default speaker (as set in preferences) should be the coordinator when grouping other speakers. Lookup 2025 Sonos office documentation for implementation details.
+
+## Enhancements
+- **Accessibility settings prompt on first launch**: When the app first loads, the user should be prompted to enable the required accessibility settings so they don't have to dig for them in System Settings.
+
+## Bugs
+- None currently
+
 ## Completed Improvements
 - ✅ Custom Sonos speaker icon for menu bar (replaces "S" text)
 - ✅ Exit/quit icon updated to "person leaving" (SF Symbol: figure.walk.departure)
@@ -13,9 +22,6 @@
 - ✅ Improved device discovery reliability with multiple SSDP packets and longer timeouts (PR #14)
 - ✅ Added loading indicator UI when discovering speakers (PR #14)
 - ✅ Development workflow documentation (DEVELOPMENT.md)
-
-## Future Ideas
-- grouping speakers with default: ultrathink on this, make it so i can group speakers easily, my default speaker as set in preferences should be the audio source when grouping other speakers. make sure to lookup 2025 office sonos documentation 09
-- when the app first loads, and the default speaker is confirmed as part of the current topology, update the current volume to match the default speaker, if the default speaker is unavailable, leave blank
-- Enhancement: when i load the app for the first time the user should be prompted to enable the required accessiblity settings so i don't have to dig for them
-- Enhancement: when i try to change the volume but i am not connected to the set trigger audio device, i should see a notice that looks just like the volume changer that appears when i successfully do change the volume so that I know why it is not working 
+- ✅ Volume slider syncs with default speaker on app launch (PR #15)
+- ✅ Volume slider disabled with "—" until actual volume loads (PR #15)
+- ✅ Wrong device HUD notification when volume hotkeys pressed on wrong audio device (PR #16) 

--- a/SonosVolumeController/Sources/VolumeKeyMonitor.swift
+++ b/SonosVolumeController/Sources/VolumeKeyMonitor.swift
@@ -110,6 +110,17 @@ class VolumeKeyMonitor {
         // Check if we should intercept
         guard audioMonitor.shouldInterceptVolumeKeys else {
             print("   ❌ Not intercepting - wrong audio device")
+
+            // Show notification explaining why volume control didn't work
+            // Capture trigger device name before entering Task to avoid data race
+            let triggerDevice = settings.triggerDeviceName
+            Task { @MainActor in
+                VolumeHUD.shared.showError(
+                    title: "Wrong Audio Device",
+                    message: "Switch to \(triggerDevice) to control Sonos"
+                )
+            }
+
             // Pass through to system
             return Unmanaged.passUnretained(event)
         }


### PR DESCRIPTION
## Summary
Shows a clear notification when user presses volume hotkeys while connected to the wrong audio device, explaining why Sonos volume control didn't activate.

## Problem
When users press volume hotkeys (F11/F12) while not connected to their configured trigger audio device, nothing happens and there's no feedback. This leads to confusion - users don't understand why the app isn't working.

## Solution
Added error notification using the same HUD style as the volume display:
- **Orange warning icon** (exclamationmark.triangle.fill) 
- **Clear message**: "Wrong Audio Device" / "Switch to {device} to control Sonos"
- **Auto-dismisses** after 2 seconds
- **Consistent visual language** with existing volume HUD

## Implementation
**VolumeHUD.swift**:
- Added `showError(title: String, message: String)` method
- Added `createErrorPanel()` to display warning-style HUD
- Reuses same panel infrastructure with different content

**VolumeKeyMonitor.swift**:
- Detects when `shouldInterceptVolumeKeys` is false
- Captures trigger device name before Task to avoid data races
- Calls `VolumeHUD.shared.showError()` with informative message
- Still passes event through to system

## Test plan
- [x] Code compiles successfully
- [x] Build completes without errors
- To test manually:
  1. Configure trigger device in preferences
  2. Switch to different audio device
  3. Press F11 or F12
  4. Should see orange warning HUD with helpful message

## Benefits
- Users immediately understand why volume control didn't work
- Clear, actionable guidance on what to do
- Reduces confusion and support questions
- Professional UX that matches the rest of the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)