### PR TITLE
Fix: Eliminate HUD flicker on rapid volume changes

### DIFF
--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -11,7 +11,6 @@
 
 ## Enhancements
 - **Accessibility settings prompt on first launch**: When the app first loads, the user should be prompted to enable the required accessibility settings so they don't have to dig for them in System Settings.
-- **Smooth volume HUD transitions**: Volume HUD flickers when changing volume rapidly (multiple hotkey presses). Need smoother transitions that handle rapid updates gracefully.
 
 ## Bugs
 - None currently
@@ -26,4 +25,5 @@
 - ✅ Volume slider syncs with default speaker on app launch (PR #15)
 - ✅ Volume slider disabled with "—" until actual volume loads (PR #15)
 - ✅ Wrong device HUD notification when volume hotkeys pressed on wrong audio device (PR #16)
-- ✅ Menu bar popover auto-close using global event monitor (PR #17) 
+- ✅ Menu bar popover auto-close using global event monitor (PR #17)
+- ✅ Smooth volume HUD transitions without flicker on rapid hotkey presses (PR #18) 


### PR DESCRIPTION
## Summary
- Fixed volume HUD flicker when changing volume rapidly with hotkeys
- Implemented smart fade animation logic that only fades in when HUD is not already visible
- Added fade-out animation state tracking to cancel in-progress animations

## Problem
When pressing volume hotkeys rapidly (F11/F12), the HUD would flicker because:
1. Every `show()` call reset `alphaValue` to 0
2. Then animated back to 1.0, even if HUD was already fully visible
3. This caused visible flashing on rapid updates

## Solution
**Added fade animation state tracking:**
- Track `isFadingOut` flag to know when fade-out is in progress
- Cancel fade-out animations if new volume update arrives
- Check if panel is already visible (`alphaValue > 0.5`)

**Smart fade-in logic:**
- Only perform fade-in animation when HUD is NOT already visible
- When already visible, skip animation and maintain full opacity
- Updates content smoothly without resetting transparency

## Changes
- Added `isFadingOut` property to track fade-out animation state
- Modified `show()` to check visibility before animating
- Modified `hide()` to set/clear fade-out flag
- Applied same logic to `showError()` for consistency

## Test Plan
- Run app with `swift run`
- Press volume hotkeys (F11/F12) rapidly multiple times
- Verify HUD updates smoothly without flickering
- Verify HUD still fades in nicely on first appearance
- Verify HUD still fades out after inactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)