### PR TITLE
Feature: Accessibility permissions prompt on first launch

### DIFF
--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -10,7 +10,7 @@
 - **Speaker grouping functionality**: Make it easy to group speakers with the default speaker as the audio source. The default speaker (as set in preferences) should be the coordinator when grouping other speakers. Lookup 2025 Sonos office documentation for implementation details.
 
 ## Enhancements
-- **Accessibility settings prompt on first launch**: When the app first loads, the user should be prompted to enable the required accessibility settings so they don't have to dig for them in System Settings.
+- None currently
 
 ## Bugs
 - None currently
@@ -26,4 +26,5 @@
 - ✅ Volume slider disabled with "—" until actual volume loads (PR #15)
 - ✅ Wrong device HUD notification when volume hotkeys pressed on wrong audio device (PR #16)
 - ✅ Menu bar popover auto-close using global event monitor (PR #17)
-- ✅ Smooth volume HUD transitions without flicker on rapid hotkey presses (PR #18) 
+- ✅ Smooth volume HUD transitions without flicker on rapid hotkey presses (PR #18)
+- ✅ Accessibility permissions prompt on first launch with direct link to System Settings (PR #19) 

--- a/SonosVolumeController/Sources/AppSettings.swift
+++ b/SonosVolumeController/Sources/AppSettings.swift
@@ -13,6 +13,7 @@ class AppSettings {
         static let volumeUpKeyCode = "volumeUpKeyCode"
         static let volumeDownModifiers = "volumeDownModifiers"
         static let volumeUpModifiers = "volumeUpModifiers"
+        static let hasShownAccessibilityPrompt = "hasShownAccessibilityPrompt"
     }
 
     var enabled: Bool {
@@ -89,6 +90,15 @@ class AppSettings {
         }
         set {
             defaults.set(Int(newValue), forKey: Keys.volumeUpModifiers)
+        }
+    }
+
+    var hasShownAccessibilityPrompt: Bool {
+        get {
+            defaults.bool(forKey: Keys.hasShownAccessibilityPrompt)
+        }
+        set {
+            defaults.set(newValue, forKey: Keys.hasShownAccessibilityPrompt)
         }
     }
 

--- a/SonosVolumeController/Sources/main.swift
+++ b/SonosVolumeController/Sources/main.swift
@@ -18,6 +18,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         settings = AppSettings()
         print("✅ Settings initialized")
 
+        // Check accessibility permissions on first launch
+        checkAccessibilityPermissions()
+
         // Initialize preferences window
         preferencesWindow = PreferencesWindow(appDelegate: self)
 
@@ -127,6 +130,50 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         print("📱 Devices discovered, updating popover...")
         // Just refresh UI - device selection happens in completion handler
         menuBarPopover.refresh()
+    }
+
+    // MARK: - Accessibility Permissions
+
+    func checkAccessibilityPermissions() {
+        // Check if we've already shown the prompt
+        if settings.hasShownAccessibilityPrompt {
+            return
+        }
+
+        // Check if accessibility is already granted
+        let trusted = AXIsProcessTrusted()
+        if trusted {
+            return
+        }
+
+        // Show prompt and mark as shown
+        showAccessibilityPrompt()
+        settings.hasShownAccessibilityPrompt = true
+    }
+
+    private func showAccessibilityPrompt() {
+        let alert = NSAlert()
+        alert.messageText = "Accessibility Permission Required"
+        alert.informativeText = """
+        Sonos Volume Controller needs accessibility permissions to capture volume hotkeys (F11/F12).
+
+        Click "Open System Settings" to grant permission, then add this app to the list.
+        """
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Open System Settings")
+        alert.addButton(withTitle: "Later")
+
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            openAccessibilitySettings()
+        }
+    }
+
+    private func openAccessibilitySettings() {
+        // Open System Settings to Privacy & Security > Accessibility
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+            NSWorkspace.shared.open(url)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Implemented user-friendly accessibility permissions prompt on first launch
- Guides users to enable required permissions instead of silent console warning
- Provides direct link to System Settings accessibility pane

## Problem
Previously, when the app launched without accessibility permissions:
- Only printed console warning: "⚠️ Please grant accessibility permissions..."
- Users had to manually navigate to System Settings > Privacy & Security > Accessibility
- No visible indication to users that permissions were needed
- Poor first-time user experience

## Solution
**Added first-launch permission check:**
- Checks if accessibility is granted on app launch
- Only shows prompt once (tracked via UserDefaults)
- If already granted, no prompt shown

**User-friendly alert dialog:**
- Clear title: "Accessibility Permission Required"
- Explains why permissions are needed (capture F11/F12 hotkeys)
- Two buttons:
  - "Open System Settings" - directly opens accessibility preferences
  - "Later" - dismisses prompt

**Persistent tracking:**
- Added `hasShownAccessibilityPrompt` property to AppSettings
- Prompt only shown once per installation
- Won't annoy users on subsequent launches

## Changes

### AppSettings.swift
- Added `hasShownAccessibilityPrompt` key to UserDefaults keys
- Added boolean property with getter/setter for tracking

### main.swift (AppDelegate)
- Added `checkAccessibilityPermissions()` - checks if prompt needed
- Added `showAccessibilityPrompt()` - displays NSAlert with options
- Added `openAccessibilitySettings()` - opens System Settings directly
- Integrated check into `applicationDidFinishLaunching()` (after settings init)

## Implementation Details

**Permission Check Flow:**
1. App launches, settings initialized
2. `checkAccessibilityPermissions()` called
3. Check if prompt already shown → exit if yes
4. Check if accessibility already granted → exit if yes
5. Show prompt and mark as shown

**System Settings URL:**
`x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility`

## Test Plan
- [ ] Fresh install: Verify prompt appears on first launch
- [ ] Click "Open System Settings": Verify it opens accessibility pane
- [ ] Click "Later": Verify prompt dismisses
- [ ] Restart app: Verify prompt does NOT show again
- [ ] Grant permissions manually: Verify prompt never shows
- [ ] Delete app preferences (UserDefaults): Verify prompt shows again

## Screenshots
Alert appearance:
- Modal dialog with informative text
- Two clear action buttons
- Non-intrusive but informative

🤖 Generated with [Claude Code](https://claude.com/claude-code)