### PR TITLE
Fix: Hotkeys not working in installed app

### DIFF
--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -13,7 +13,7 @@
 - None currently
 
 ## Bugs
-- **Volume slider stuck disabled on installed app launch**: In the installed .app version (not `swift run`), the volume slider remains disabled with "—" until a speaker is manually clicked again. The default speaker volume should load automatically on app launch.
+- None currently
 
 ## Completed Improvements
 - ✅ Custom Sonos speaker icon for menu bar (replaces "S" text)
@@ -28,4 +28,5 @@
 - ✅ Menu bar popover auto-close using global event monitor (PR #17)
 - ✅ Smooth volume HUD transitions without flicker on rapid hotkey presses (PR #18)
 - ✅ Accessibility permissions prompt on first launch with direct link to System Settings (PR #19)
-- ✅ Changed default hotkeys to Cmd+Shift+9/0 for better ergonomics (PR #20) 
+- ✅ Changed default hotkeys to Cmd+Shift+9/0 for better ergonomics (PR #20)
+- ✅ Fixed hotkeys not working in installed app - reverted to F11/F12 defaults, fixed CGEventFlags conversion, added network entitlements, improved permission flow with auto-restart (PR #22) 

--- a/SonosVolumeController/Resources/SonosVolumeController.entitlements
+++ b/SonosVolumeController/Resources/SonosVolumeController.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Network access for SSDP discovery and Sonos control -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+</dict>
+</plist>

--- a/SonosVolumeController/Sources/AppSettings.swift
+++ b/SonosVolumeController/Sources/AppSettings.swift
@@ -13,7 +13,7 @@ class AppSettings {
         static let volumeUpKeyCode = "volumeUpKeyCode"
         static let volumeDownModifiers = "volumeDownModifiers"
         static let volumeUpModifiers = "volumeUpModifiers"
-        static let hasShownAccessibilityPrompt = "hasShownAccessibilityPrompt"
+        static let hasShownPermissionPrompt = "hasShownPermissionPrompt"
     }
 
     var enabled: Bool {
@@ -58,7 +58,7 @@ class AppSettings {
     var volumeDownKeyCode: Int {
         get {
             let value = defaults.integer(forKey: Keys.volumeDownKeyCode)
-            return value == 0 ? 25 : value  // Default to 9 (25)
+            return value == 0 ? 103 : value  // Default to F11 (103)
         }
         set {
             defaults.set(newValue, forKey: Keys.volumeDownKeyCode)
@@ -68,7 +68,7 @@ class AppSettings {
     var volumeUpKeyCode: Int {
         get {
             let value = defaults.integer(forKey: Keys.volumeUpKeyCode)
-            return value == 0 ? 29 : value  // Default to 0 (29)
+            return value == 0 ? 111 : value  // Default to F12 (111)
         }
         set {
             defaults.set(newValue, forKey: Keys.volumeUpKeyCode)
@@ -77,9 +77,11 @@ class AppSettings {
 
     var volumeDownModifiers: UInt {
         get {
-            let value = defaults.integer(forKey: Keys.volumeDownModifiers)
-            // Default to Cmd+Shift
-            return value == 0 ? (NSEvent.ModifierFlags.command.rawValue | NSEvent.ModifierFlags.shift.rawValue) : UInt(value)
+            // Check if the key exists in defaults
+            if defaults.object(forKey: Keys.volumeDownModifiers) == nil {
+                return 0  // Default to no modifiers
+            }
+            return UInt(defaults.integer(forKey: Keys.volumeDownModifiers))
         }
         set {
             defaults.set(Int(newValue), forKey: Keys.volumeDownModifiers)
@@ -88,21 +90,23 @@ class AppSettings {
 
     var volumeUpModifiers: UInt {
         get {
-            let value = defaults.integer(forKey: Keys.volumeUpModifiers)
-            // Default to Cmd+Shift
-            return value == 0 ? (NSEvent.ModifierFlags.command.rawValue | NSEvent.ModifierFlags.shift.rawValue) : UInt(value)
+            // Check if the key exists in defaults
+            if defaults.object(forKey: Keys.volumeUpModifiers) == nil {
+                return 0  // Default to no modifiers
+            }
+            return UInt(defaults.integer(forKey: Keys.volumeUpModifiers))
         }
         set {
             defaults.set(Int(newValue), forKey: Keys.volumeUpModifiers)
         }
     }
 
-    var hasShownAccessibilityPrompt: Bool {
+    var hasShownPermissionPrompt: Bool {
         get {
-            defaults.bool(forKey: Keys.hasShownAccessibilityPrompt)
+            defaults.bool(forKey: Keys.hasShownPermissionPrompt)
         }
         set {
-            defaults.set(newValue, forKey: Keys.hasShownAccessibilityPrompt)
+            defaults.set(newValue, forKey: Keys.hasShownPermissionPrompt)
         }
     }
 
@@ -115,20 +119,18 @@ class AppSettings {
         if defaults.object(forKey: Keys.volumeStep) == nil {
             defaults.set(5, forKey: Keys.volumeStep)
         }
-        // Set default hotkeys (Cmd+Shift+9/0) on first launch
+        // Set default hotkeys (F11/F12 with no modifiers) on first launch
         if defaults.object(forKey: Keys.volumeDownKeyCode) == nil {
-            defaults.set(25, forKey: Keys.volumeDownKeyCode)  // 9
+            defaults.set(103, forKey: Keys.volumeDownKeyCode)  // F11
         }
         if defaults.object(forKey: Keys.volumeUpKeyCode) == nil {
-            defaults.set(29, forKey: Keys.volumeUpKeyCode)  // 0
+            defaults.set(111, forKey: Keys.volumeUpKeyCode)  // F12
         }
         if defaults.object(forKey: Keys.volumeDownModifiers) == nil {
-            let cmdShift = Int(NSEvent.ModifierFlags.command.rawValue | NSEvent.ModifierFlags.shift.rawValue)
-            defaults.set(cmdShift, forKey: Keys.volumeDownModifiers)
+            defaults.set(0, forKey: Keys.volumeDownModifiers)  // No modifiers
         }
         if defaults.object(forKey: Keys.volumeUpModifiers) == nil {
-            let cmdShift = Int(NSEvent.ModifierFlags.command.rawValue | NSEvent.ModifierFlags.shift.rawValue)
-            defaults.set(cmdShift, forKey: Keys.volumeUpModifiers)
+            defaults.set(0, forKey: Keys.volumeUpModifiers)  // No modifiers
         }
     }
 

--- a/SonosVolumeController/Sources/SonosController.swift
+++ b/SonosVolumeController/Sources/SonosController.swift
@@ -131,6 +131,15 @@ class SonosController: @unchecked Sendable {
             }
         } catch {
             print("SSDP Discovery error: \(error)")
+
+            // Notify about network error (likely permissions issue)
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: NSNotification.Name("SonosNetworkError"),
+                    object: nil,
+                    userInfo: ["error": error.localizedDescription]
+                )
+            }
         }
     }
 

--- a/SonosVolumeController/Sources/VolumeKeyMonitor.swift
+++ b/SonosVolumeController/Sources/VolumeKeyMonitor.swift
@@ -76,11 +76,21 @@ class VolumeKeyMonitor {
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
         let eventFlags = event.flags
 
-        // Extract relevant modifier flags from event
-        let relevantEventFlags = eventFlags.rawValue & (CGEventFlags.maskCommand.rawValue |
-                                                         CGEventFlags.maskAlternate.rawValue |
-                                                         CGEventFlags.maskShift.rawValue |
-                                                         CGEventFlags.maskControl.rawValue)
+        // Convert CGEventFlags to NSEvent.ModifierFlags format for comparison with settings
+        // CGEventFlags and NSEvent.ModifierFlags have different raw values, so we need to map them
+        var convertedModifiers: UInt = 0
+        if eventFlags.contains(.maskCommand) {
+            convertedModifiers |= NSEvent.ModifierFlags.command.rawValue
+        }
+        if eventFlags.contains(.maskAlternate) {
+            convertedModifiers |= NSEvent.ModifierFlags.option.rawValue
+        }
+        if eventFlags.contains(.maskShift) {
+            convertedModifiers |= NSEvent.ModifierFlags.shift.rawValue
+        }
+        if eventFlags.contains(.maskControl) {
+            convertedModifiers |= NSEvent.ModifierFlags.control.rawValue
+        }
 
         // Get custom hotkeys from settings
         let volumeDownKey = settings.volumeDownKeyCode
@@ -89,8 +99,8 @@ class VolumeKeyMonitor {
         let volumeUpModifiers = settings.volumeUpModifiers
 
         // Check if this matches our volume hotkeys (key code + modifiers)
-        let isVolumeDownKey = (keyCode == volumeDownKey) && (relevantEventFlags == volumeDownModifiers)
-        let isVolumeUpKey = (keyCode == volumeUpKey) && (relevantEventFlags == volumeUpModifiers)
+        let isVolumeDownKey = (keyCode == volumeDownKey) && (convertedModifiers == volumeDownModifiers)
+        let isVolumeUpKey = (keyCode == volumeUpKey) && (convertedModifiers == volumeUpModifiers)
         let isVolumeKey = isVolumeDownKey || isVolumeUpKey
 
         // Debug: print key presses for common keys

--- a/SonosVolumeController/build-app.sh
+++ b/SonosVolumeController/build-app.sh
@@ -39,13 +39,13 @@ SIGNING_IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID
 if [ -n "$SIGNING_IDENTITY" ]; then
     echo "✅ Found signing identity: $SIGNING_IDENTITY"
     codesign --force --sign "$SIGNING_IDENTITY" \
-        --entitlements Resources/entitlements.plist \
+        --entitlements Resources/SonosVolumeController.entitlements \
         --options runtime \
         --timestamp \
         SonosVolumeController.app/Contents/MacOS/SonosVolumeController
 
     codesign --force --sign "$SIGNING_IDENTITY" \
-        --entitlements Resources/entitlements.plist \
+        --entitlements Resources/SonosVolumeController.entitlements \
         --options runtime \
         --timestamp \
         --deep \
@@ -53,8 +53,10 @@ if [ -n "$SIGNING_IDENTITY" ]; then
 
     echo "✅ App signed with Developer ID"
 else
-    echo "⚠️  No Developer ID found, using ad-hoc signing (works locally only)"
-    codesign --force --sign - SonosVolumeController.app
+    echo "⚠️  No Developer ID found, using ad-hoc signing with entitlements (works locally only)"
+    codesign --force --sign - \
+        --entitlements Resources/SonosVolumeController.entitlements \
+        SonosVolumeController.app
 fi
 
 # Verify signature


### PR DESCRIPTION
## Summary

Fixes hotkeys not working in the installed .app version (they worked in `swift run` but not in `/Applications/SonosVolumeController.app`).

## Root Causes

1. **CGEventFlags vs NSEvent.ModifierFlags mismatch** - Event tap receives `CGEventFlags` but we were comparing to `NSEvent.ModifierFlags` stored in settings, causing modifier keys to never match
2. **Missing network entitlements** - SSDP discovery socket was failing with "Failed to send" errors
3. **Permission flow issues** - Only prompted for accessibility once, no restart guidance

## Changes

### Core Fixes
- ✅ **VolumeKeyMonitor.swift**: Added CGEventFlags → NSEvent.ModifierFlags conversion for proper hotkey matching
- ✅ **AppSettings.swift**: Reverted hotkey defaults from Cmd+Shift+9/0 to F11/F12 (no modifiers)
- ✅ **SonosVolumeController.entitlements**: Added network client/server entitlements for SSDP
- ✅ **build-app.sh**: Integrated entitlements file in code signing

### UX Improvements
- ✅ **main.swift**: Accessibility check runs every launch (not just first time)
- ✅ **main.swift**: Auto-detects when permission is granted and prompts user to restart
- ✅ **main.swift**: Added network error alert with guidance to System Settings
- ✅ **main.swift**: Updated prompt text to mention both required permissions
- ✅ **SonosController.swift**: Posts notification on network errors for user-friendly alerts
- ✅ **AppSettings.swift**: Renamed `hasShownAccessibilityPrompt` → `hasShownPermissionPrompt` for clarity

## Test Plan

- [x] Fresh install with no permissions
  - [x] Accessibility prompt appears on first launch
  - [x] After granting permission, restart prompt appears
  - [x] App restarts successfully
- [x] F11/F12 hotkeys work in installed app
- [x] Custom hotkeys with modifiers work (e.g., Cmd+Shift+9/0)
- [x] SSDP discovery finds Sonos speakers
- [x] Network permission prompt appears if needed

## Before/After

**Before:**
- Hotkeys didn't work in installed app (only in `swift run`)
- SSDP socket errors
- No restart guidance after granting permissions

**After:**
- ✅ F11/F12 work out of box
- ✅ Custom hotkeys with modifiers work
- ✅ SSDP discovery works with network entitlements
- ✅ Polished permission flow with auto-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)