### PR TITLE
Add trigger device picker to menu bar

### DIFF
--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -30,4 +30,5 @@
 - ✅ Accessibility permissions prompt on first launch with direct link to System Settings (PR #19)
 - ✅ Changed default hotkeys to Cmd+Shift+9/0 for better ergonomics (PR #20)
 - ✅ Fixed hotkeys not working in installed app - reverted to F11/F12 defaults, fixed CGEventFlags conversion, added network entitlements, improved permission flow with auto-restart (PR #22)
-- ✅ First launch onboarding with welcome banner - automatically shows popover when no speaker is selected, plus shows HUD notification when user tries to use hotkeys without a speaker selected (PR #24) 
+- ✅ First launch onboarding with welcome banner - automatically shows popover when no speaker is selected, plus shows HUD notification when user tries to use hotkeys without a speaker selected (PR #24)
+- ✅ Trigger device picker in menu bar - select which audio device activates Sonos hotkeys, defaults to "Any Device" for universal compatibility 

--- a/SonosVolumeController/Sources/AppSettings.swift
+++ b/SonosVolumeController/Sources/AppSettings.swift
@@ -28,11 +28,11 @@ class AppSettings {
 
     var triggerDeviceName: String {
         get {
-            defaults.string(forKey: Keys.triggerDevice) ?? "DELL U2723QE"
+            defaults.string(forKey: Keys.triggerDevice) ?? ""  // Empty = always intercept
         }
         set {
             defaults.set(newValue, forKey: Keys.triggerDevice)
-            print("Trigger device set to: \(newValue)")
+            print("Trigger device set to: \(newValue.isEmpty ? "Any Device" : newValue)")
         }
     }
 

--- a/SonosVolumeController/Sources/AudioDeviceMonitor.swift
+++ b/SonosVolumeController/Sources/AudioDeviceMonitor.swift
@@ -17,6 +17,13 @@ class AudioDeviceMonitor {
 
     var shouldInterceptVolumeKeys: Bool {
         guard settings.enabled else { return false }
+
+        // If trigger device is empty, always intercept (works with any audio device)
+        if settings.triggerDeviceName.isEmpty {
+            return true
+        }
+
+        // Otherwise, only intercept when current device matches trigger device
         return currentDeviceName == settings.triggerDeviceName
     }
 


### PR DESCRIPTION
## Summary
- Removed hardcoded "DELL U2723QE" trigger device default
- Changed default to empty string = "Any Device" mode (works with all audio outputs)
- Added "Audio Trigger" section in menu bar popover with radio button selection
- Users can choose "Any Device (recommended)" or specific audio output devices
- Hotkeys only trigger when selected audio device is active
- Error message now only shows when specific trigger device is set and doesn't match

## What does this solve?
Previously, the app had a hardcoded trigger device ("DELL U2723QE"), which meant hotkeys wouldn't work for users with different audio setups (like built-in speakers). This fixes that by:

1. **Out-of-the-box compatibility**: Defaults to "Any Device" mode - hotkeys work regardless of audio output
2. **User control**: Power users can restrict hotkeys to specific devices (e.g., only when external monitor speakers are active)
3. **Clear UI**: Easy-to-use picker directly in menu bar popover (no need to dig into Preferences)

## UI Preview
New "Audio Trigger" section shows:
- 🎧 Audio Trigger
- "Hotkeys work when this device is active:"
- ○ Any Device (recommended) ← default
- ○ MacBook Pro Speakers
- ○ DELL U2723QE
- ○ [other detected audio devices...]

## Test plan
- [x] Built and ran with `swift run`
- [x] Cleared UserDefaults - verified empty trigger device default
- [x] Confirmed "Any Device" is selected by default in UI
- [x] Tested trigger device selection updates settings
- [x] Verified hotkeys work in "Any Device" mode
- [x] Updated FEATURES.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)