### PR TITLE
Speaker Grouping & Volume Control

### DIFF
--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -7,8 +7,9 @@
 - [ ] App Store submission
 
 ## Features
-- **Speaker grouping functionality**: Make it easy to group speakers with the default speaker as the audio source. The default speaker (as set in preferences) should be the coordinator when grouping other speakers. Lookup 2025 Sonos office documentation for implementation details.
+- **Real-time group topology updates**: Subscribe to Sonos topology events to automatically refresh group information when changed from another app (Sonos app, Alexa, etc.). Follow Sonos best practices for ZoneGroupTopology event subscription and handling `groupCoordinatorChanged` events.
 - **Trigger device cache management**: Add ability to refresh trigger sources and cache them persistently. Users should be able to manually delete cached devices that are no longer relevant (similar to WiFi network history - devices remain in cache even when not currently available, but can be manually removed).
+- **Sonos-style speaker cards**: Redesign speaker list UI to match Sonos native app style - dark rounded cards per speaker/group, individual volume sliders on each card, cleaner visual hierarchy.
 
 ## Enhancements
 - None currently

--- a/SonosVolumeController/Sources/MenuBarContentView.swift
+++ b/SonosVolumeController/Sources/MenuBarContentView.swift
@@ -686,6 +686,18 @@ class MenuBarContentViewController: NSViewController {
         guard let card = gesture.view,
               let deviceName = card.identifier?.rawValue else { return }
 
+        // Check if click was on the checkbox - if so, ignore it
+        let clickLocation = gesture.location(in: card)
+        for subview in card.subviews {
+            if subview is NSButton {
+                let checkboxFrame = subview.frame
+                if checkboxFrame.contains(clickLocation) {
+                    // Click was on checkbox, let it handle the event
+                    return
+                }
+            }
+        }
+
         appDelegate?.sonosController.selectDevice(name: deviceName)
         appDelegate?.settings.selectedSonosDevice = deviceName
 

--- a/SonosVolumeController/docs/sonos-api/control.md
+++ b/SonosVolumeController/docs/sonos-api/control.md
@@ -1,0 +1,75 @@
+# Sonos Control API Overview
+
+## Key Concepts
+
+### Accounts, Households, and Groups
+
+- A Sonos account includes product registration and contact information
+- A household is a set of players on the same network
+- Groups are collections of players that play synchronized audio
+- Each household has a unique `householdId`
+- Players can be moved between groups without interrupting playback
+
+### Communication Basics
+
+- Uses HTTP and JSON for communication
+- Commands are sent to the Sonos cloud at `api.ws.sonos.com/control/api`
+- Supports different targets:
+  - Households
+  - Groups
+  - Sessions
+  - Players
+
+### Command Structure
+
+Example command path:
+```
+https://api.ws.sonos.com/control/api/v1/groups/{groupId}/playback/content
+```
+
+### Key HTTP Headers
+
+- `Authorization`: Bearer token
+- `Content-Type`: application/json
+- `User-Agent`: Recommended for tracking requests
+
+### Response Types
+
+- 200 OK: Successful command
+- 400 Bad Request: Syntax errors
+- 401 Unauthorized: Invalid credentials
+- 499: Custom errors with detailed error codes
+
+## Playback Control
+
+### Loading Content
+
+You can load content into a group's queue with:
+- Content type (album, track, playlist)
+- Service ID
+- Object ID
+- Optional playback actions (play/pause)
+- Play modes (repeat, shuffle)
+
+### Example Content Load Payload
+
+```json
+{
+ "type": "ALBUM",
+ "id": {
+   "objectId": "spotify:album:2QgGoL5VSQhPHudTObS7zK",
+   "serviceId": "12"
+ },
+ "playbackAction": "PLAY",
+ "playModes": {
+   "repeat": true
+ }
+}
+```
+
+## Best Practices
+
+- Handle potential errors gracefully
+- Provide a meaningful User-Agent
+- Respect rate limits
+- Use appropriate authentication

--- a/SonosVolumeController/docs/sonos-api/groups.md
+++ b/SonosVolumeController/docs/sonos-api/groups.md
@@ -1,0 +1,55 @@
+# Sonos Groups: Comprehensive Guide
+
+## Overview
+
+Sonos groups represent a core feature of the Sonos sound system, allowing listeners to synchronize music playback across multiple speakers in different rooms. The groups functionality is fundamental to the Sonos experience.
+
+## Key Concepts
+
+### Group Characteristics
+
+- A group can include one or more Sonos speakers
+- Groups allow synchronized playback across multiple rooms
+- Groups can be dynamically created, modified, and dissolved
+
+### Group Management Requirements
+
+1. **Accurate Group Tracking**
+   - Apps must keep group information up-to-date in real-time
+   - Groups can change in other apps or integrations
+   - Continuous tracking is essential for a seamless user experience
+
+2. **Group Discovery**
+   - Apps should display current Sonos speaker groupings
+   - Allow users to select and interact with groups
+   - Highlight selected groups visually
+
+### Group Coordination
+
+The system supports dynamic group changes through events like `groupCoordinatorChanged`, which can signal:
+- Group status updates
+- Group dissolution
+- Speaker movement between groups
+
+## Technical Implementation
+
+### API Endpoints for Group Management
+
+- `getGroups`: Retrieve current household groups
+- `createGroup`: Establish new speaker groups
+- `modifyGroupMembers`: Add or remove speakers from groups
+- `setGroupMembers`: Completely redefine group composition
+
+### Best Practices
+
+- Continuously refresh group information
+- Handle group changes gracefully
+- Provide clear visual feedback on group status
+- Support real-time group modifications
+
+## User Experience Considerations
+
+- Groups should feel "magical" and predictable
+- Seamless music continuity across rooms
+- Intuitive group creation and management
+- Minimal user intervention required

--- a/SonosVolumeController/docs/sonos-api/upnp-local-api.md
+++ b/SonosVolumeController/docs/sonos-api/upnp-local-api.md
@@ -1,0 +1,208 @@
+# Sonos UPnP/SOAP Local API
+
+## Overview
+
+Sonos speakers expose a local UPnP (Universal Plug and Play) API that allows programmatic control through SOAP (Simple Object Access Protocol) requests on the local network. Every Sonos speaker has several SOAP services, each with one or more actions you can call.
+
+**Important**: This is the API we use in SonosVolumeController - direct device communication without cloud dependencies.
+
+## Network Communication
+
+- **HTTP Port**: 1400
+- **SSDP Port**: 1900 (UDP for discovery)
+- **Base URL**: `http://{speaker-ip}:1400`
+
+## Key Services
+
+### 1. ZoneGroupTopology Service
+
+**Endpoint**: `/ZoneGroupTopology/Control`
+
+**Purpose**: Handles network topology, group information, diagnostics
+
+**Key Actions**:
+- `GetZoneGroupState` - Returns complete group topology XML
+- `GetZoneGroupAttributes` - Get group attributes
+- `RegisterMobileDevice` - Register for notifications
+
+**SOAP Action Header**: `"urn:schemas-upnp-org:service:ZoneGroupTopology:1#{ActionName}"`
+
+**Example GetZoneGroupState Request**:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
+            s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <s:Body>
+    <u:GetZoneGroupState xmlns:u="urn:schemas-upnp-org:service:ZoneGroupTopology:1">
+    </u:GetZoneGroupState>
+  </s:Body>
+</s:Envelope>
+```
+
+**Response Format**: Contains `<ZoneGroupState>` with HTML-encoded XML containing:
+- `<ZoneGroup>` elements with `Coordinator` attribute
+- `<ZoneGroupMember>` elements with:
+  - `UUID` - unique device identifier
+  - `Invisible` - "1" for satellite speakers in stereo pairs
+  - `ChannelMapSet` - stereo pair configuration
+  - `Location` - device URL
+
+### 2. AVTransport Service
+
+**Endpoint**: `/MediaRenderer/AVTransport/Control`
+
+**Purpose**: Transport control (play, pause, seek, queue management)
+
+**Key Actions**:
+- `AddURIToQueue` - Add songs to queue
+- `BecomeGroupCoordinatorAndSource` - Leave group (ungroup)
+- `DelegateGroupCoordinationTo` - Transfer coordinator role
+- `SetAVTransportURI` - Set current playback URI
+- `Play` - Start playback
+- `Pause` - Pause playback
+- `Stop` - Stop playback
+- `Next` - Skip to next track
+- `Previous` - Go to previous track
+
+**SOAP Action Header**: `"urn:schemas-upnp-org:service:AVTransport:1#{ActionName}"`
+
+### 3. RenderingControl Service
+
+**Endpoint**: `/MediaRenderer/RenderingControl/Control`
+
+**Purpose**: Individual speaker volume and audio settings
+
+**Key Actions**:
+- `GetVolume` - Get current volume (0-100)
+- `SetVolume` - Set absolute volume level
+- `GetMute` - Get mute state (0 or 1)
+- `SetMute` - Set mute state
+
+**SOAP Action Header**: `"urn:schemas-upnp-org:service:RenderingControl:1#{ActionName}"`
+
+**Example SetVolume Request**:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
+            s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <s:Body>
+    <u:SetVolume xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1">
+      <InstanceID>0</InstanceID>
+      <Channel>Master</Channel>
+      <DesiredVolume>50</DesiredVolume>
+    </u:SetVolume>
+  </s:Body>
+</s:Envelope>
+```
+
+### 4. GroupRenderingControl Service
+
+**Endpoint**: `/MediaRenderer/GroupRenderingControl/Control` (on coordinator)
+
+**Purpose**: Group-wide volume control
+
+**Key Actions**:
+- `GetGroupVolume` - Get average group volume
+- `SetGroupVolume` - Set proportional group volume
+- `SetRelativeGroupVolume` - Adjust by delta (+/-)
+- `GetGroupMute` - Get group mute state
+- `SetGroupMute` - Mute/unmute entire group
+
+**SOAP Action Header**: `"urn:schemas-upnp-org:service:GroupRenderingControl:1#{ActionName}"`
+
+**Important**: Group volume commands must be sent to the **group coordinator**, not individual members.
+
+## Group Management via UPnP
+
+### Creating Groups
+
+To create a group, use AVTransport service:
+
+**Action**: `SetAVTransportURI` on the desired coordinator with special URI
+
+**URI Format**: `x-rincon:{COORDINATOR_UUID}`
+
+This makes a speaker join the group of the coordinator.
+
+### Ungrouping
+
+**Action**: `BecomeGroupCoordinatorAndSource` on the speaker to ungroup
+
+This removes the speaker from its current group and makes it standalone.
+
+### Group Coordinator
+
+- One speaker in each group is the **coordinator**
+- The coordinator manages playback for the entire group
+- Group volume commands must go to the coordinator
+- Individual volume commands can go to any member
+
+## Volume Control Patterns
+
+### Individual Speaker Volume
+```
+POST http://{speaker-ip}:1400/MediaRenderer/RenderingControl/Control
+Action: SetVolume
+Parameters: InstanceID=0, Channel=Master, DesiredVolume={0-100}
+```
+
+### Group Volume (Proportional)
+```
+POST http://{coordinator-ip}:1400/MediaRenderer/GroupRenderingControl/Control
+Action: SetGroupVolume
+Parameters: InstanceID=0, DesiredVolume={0-100}
+```
+
+This adjusts all group members proportionally, maintaining relative volume differences.
+
+### Group Volume (Relative)
+```
+POST http://{coordinator-ip}:1400/MediaRenderer/GroupRenderingControl/Control
+Action: SetRelativeGroupVolume
+Parameters: InstanceID=0, Adjustment={-100 to +100}
+```
+
+This is ideal for volume up/down buttons.
+
+## Data Types
+
+- **Booleans**: Represented as `1` (true) or `0` (false)
+- **Volume**: Integer 0-100
+- **UUIDs**: Format `RINCON_XXXXXXXXXXXX`
+
+## Discovery
+
+**SSDP Multicast**: 239.255.255.250:1900
+
+**M-SEARCH Request**:
+```
+M-SEARCH * HTTP/1.1
+HOST: 239.255.255.250:1900
+MAN: "ssdp:discover"
+MX: 3
+ST: urn:schemas-upnp-org:device:ZonePlayer:1
+```
+
+**Device Description**: `http://{speaker-ip}:1400/xml/device_description.xml`
+
+## Implementation Notes
+
+1. **Current Implementation** (SonosController.swift):
+   - Uses SSDP discovery ✓
+   - Fetches ZoneGroupTopology ✓
+   - Parses group coordinator info ✓
+   - Handles stereo pairs ✓
+   - Individual volume control via RenderingControl ✓
+
+2. **To Add for Full Grouping**:
+   - Group creation via SetAVTransportURI
+   - Ungrouping via BecomeGroupCoordinatorAndSource
+   - Group volume via GroupRenderingControl service
+   - Track full group membership (currently only tracks coordinator UUID)
+   - UI for visualizing and modifying groups
+
+## References
+
+- SoCo Python library: https://github.com/SoCo/SoCo
+- Unofficial API docs: https://sonos.svrooij.io/
+- UPnP specs: Open Connectivity Foundation MediaServer:4, MediaRenderer:3

--- a/SonosVolumeController/docs/sonos-api/volume.md
+++ b/SonosVolumeController/docs/sonos-api/volume.md
@@ -1,0 +1,60 @@
+# Volume Control in Sonos Systems
+
+## Overview
+
+Volume control in Sonos systems is a comprehensive feature that allows users to manage sound levels across individual players and groups. The system provides multiple ways to adjust volume and mute settings while maintaining a consistent and user-friendly experience.
+
+## Key Volume Control Concepts
+
+### Volume Types
+1. Group Volume
+   - Adjusts volume proportionally across all players in a group
+   - Maintains relative volume differences between players
+
+2. Player Volume
+   - Controls volume for individual Sonos players
+   - Can be adjusted independently within a group
+
+### Mute Options
+1. Group Mute
+   - Mutes all players in a group
+   - Does not permanently alter individual player volume levels
+
+2. Player Mute
+   - Mutes a specific player
+   - Preserves individual volume settings
+
+## Volume Control Best Practices
+
+### Handling Volume Changes
+- Throttle volume commands to prevent system overload
+- Store and process the most recent volume event
+- Ignore events during active user interaction
+- Update UI after user releases volume control
+
+### Implementation Guidelines
+- Use group volume commands for group-wide adjustments
+- Send volume commands to group coordinator
+- Subscribe to `groupVolume` namespace for synchronization
+- Handle potential group status changes gracefully
+
+## Volume Range and Commands
+
+- Volume range: 0-100 (percentage of maximum volume)
+- Key commands:
+  - `setVolume`: Set absolute volume level
+  - `setRelativeVolume`: Adjust volume incrementally
+  - `setMute`: Mute/unmute players or groups
+
+## Special Considerations
+
+- Some players with line-out connections (e.g., Play:5 gen 1, Connect) have unique volume behavior
+- Group volume may not affect players with external audio devices connected
+
+## Recommended Implementation Strategy
+
+1. Draw group and player volume sliders
+2. Subscribe to volume and group namespaces
+3. Implement event handling with throttling
+4. Provide responsive UI updates
+5. Handle edge cases like group changes


### PR DESCRIPTION
## Summary

Adds comprehensive Sonos speaker grouping functionality with proper group volume control following Sonos API best practices.

### Core Features

**Speaker Grouping:**
- ✅ Create groups by selecting multiple speakers via checkboxes
- ✅ "Group Selected" button to group 2+ speakers
- ✅ First selected speaker becomes group coordinator
- ✅ Groups automatically detected from Sonos topology
- ✅ Real-time topology updates after grouping/ungrouping

**Ungrouping:**
- ✅ "Ungroup Selected" button next to "Group Selected"
- ✅ Select grouped speakers and click to ungroup
- ✅ Supports ungrouping multiple speakers simultaneously
- ✅ Button enables only when grouped speakers are selected

**Group Volume Control:**
- ✅ Hotkeys (F11/F12) use `SetRelativeGroupVolume` for grouped speakers
- ✅ Volume slider uses `SetGroupVolume` for grouped speakers
- ✅ Individual speakers continue to use `SetVolume`
- ✅ Automatic detection of group membership
- ✅ Correct Sonos API usage per documentation

**Visual Indicators:**
- ✅ Group coordinators show people icon (👥) in blue
- ✅ Group members show blue vertical line indicator
- ✅ Group members indented for visual hierarchy
- ✅ Group info text: "Group leader + X speakers" / "Grouped with [coordinator]"
- ✅ Volume label shows "Group Volume (X speakers)" in blue
- ✅ Smart sorting: groups displayed together (coordinator → members)

### Technical Implementation

**Backend (SonosController.swift):**
- Added `SonosGroup` data structure with full member tracking
- Implemented `buildGroups()` to construct groups from topology
- Added `getGroupForDevice()` helper for group detection
- Implemented UPnP group management commands:
  - `addDeviceToGroup` - Join speakers (SetAVTransportURI)
  - `removeDeviceFromGroup` - Ungroup (BecomeCoordinatorOfStandaloneGroup)
  - `createGroup` - Form new groups
  - `dissolveGroup` - Ungroup all members
- Implemented GroupRenderingControl volume commands:
  - `getGroupVolume` - Fetch group volume
  - `setGroupVolume` - Absolute group volume
  - `changeGroupVolume` - Relative adjustments
- Updated `volumeUp/volumeDown` to use group volume when appropriate
- Updated `setVolume` to use group volume when appropriate
- Updated `getCurrentVolume` to fetch group volume when appropriate

**UI (MenuBarContentView.swift):**
- Enhanced speaker cards with group visual indicators
- Added volume type label ("Volume" vs "Group Volume")
- Implemented checkbox-based selection for grouping/ungrouping
- Added "Group Selected" and "Ungroup Selected" buttons
- Smart button enabling based on selection state
- Gesture recognizer delegate for proper checkbox interaction

**Documentation:**
- Created local Sonos API docs in `docs/sonos-api/`
  - `groups.md` - Group management concepts
  - `volume.md` - Volume control best practices
  - `control.md` - Control API overview
  - `upnp-local-api.md` - Complete UPnP/SOAP reference
- Added future features to FEATURES.md:
  - Real-time topology event subscription
  - Sonos-style UI redesign

### API Compliance

Follows Sonos best practices:
- ✅ Group volume uses GroupRenderingControl service
- ✅ Hotkeys use SetRelativeGroupVolume (relative adjustments)
- ✅ Slider uses SetGroupVolume (absolute control)
- ✅ Individual speakers use RenderingControl service
- ✅ Topology fetched via ZoneGroupTopology
- ✅ Direct UPnP/SOAP communication (no cloud dependency)

### Testing

Tested with real Sonos setup:
- Multiple speakers grouped successfully
- Volume control works for both groups and individuals
- Ungrouping separates speakers correctly
- Topology updates refresh UI automatically
- Works with stereo pairs and multi-speaker groups

### Future Enhancements

See FEATURES.md for planned improvements:
- Real-time topology updates via event subscription
- Sonos-style speaker card redesign
- Individual volume sliders per speaker in group

🤖 Generated with [Claude Code](https://claude.com/claude-code)