### PR TITLE
Add hierarchical group UI with expandable member controls

### DIFF
--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -32,4 +32,5 @@
 - ✅ Changed default hotkeys to Cmd+Shift+9/0 for better ergonomics (PR #20)
 - ✅ Fixed hotkeys not working in installed app - reverted to F11/F12 defaults, fixed CGEventFlags conversion, added network entitlements, improved permission flow with auto-restart (PR #22)
 - ✅ First launch onboarding with welcome banner - automatically shows popover when no speaker is selected, plus shows HUD notification when user tries to use hotkeys without a speaker selected (PR #24)
-- ✅ Trigger device picker in menu bar - select which audio device activates Sonos hotkeys, defaults to "Any Device" for universal compatibility (PR #25) 
+- ✅ Trigger device picker in menu bar - select which audio device activates Sonos hotkeys, defaults to "Any Device" for universal compatibility (PR #25)
+- ✅ Hierarchical group UI with expandable member controls - groups display as primary cards with drill-down capability to control individual speakers within groups (PR #27) 

--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -11,7 +11,7 @@
 - **Trigger device cache management**: Add ability to refresh trigger sources and cache them persistently. Users should be able to manually delete cached devices that are no longer relevant (similar to WiFi network history - devices remain in cache even when not currently available, but can be manually removed).
 
 ## Enhancements
-- None currently
+- **Simplify trigger source UI**: Replace radio button list with read-only info display showing the current trigger device. Now that "Any Device" is the default and works well, the selection UI could be streamlined to just show what's active (with option to change in preferences if needed)
 
 ## Bugs
 - **Speakers list spacing**: Adjust spacing/layout in the speakers section of the menu bar popover


### PR DESCRIPTION
## Summary

This PR adds a hierarchical UI for Sonos speaker groups, inspired by the native Sonos app design. Groups now display as primary entities with the ability to drill down and control individual members within each group.

## Key Features

✨ **Group Display**
- Groups show as single cards with combined names (e.g., "Living Room + Kitchen Move")
- Multiple speaker icon (`hifispeaker.2.fill`) to distinguish groups from individuals
- Blue accent color for group indicators

✨ **Expandable Controls**
- Chevron button to expand/collapse groups and show member speakers
- Individual volume sliders for each member within a group
- Members displayed with indentation and blue connection line

✨ **Smart Interactions**
- Click card body to set group as active/default
- Click chevron to expand/collapse members
- Checkbox for ungrouping operations
- Hotkeys automatically use group volume when group is active

✨ **Visual Polish**
- Fixed width alignment between group and individual cards
- Consistent card structure with explicit width constraints
- Volume type label shows "Group Volume (X speakers)" when controlling groups
- Smart sorting: groups above individuals, active speakers prioritized

## Implementation Details

- Added `SonosGroup` data structure to represent multi-speaker groups
- Extended `MenuBarContentView` with expandable state tracking
- Implemented `NSGestureRecognizerDelegate` to differentiate card vs button clicks
- Added individual volume control methods for group members
- Fixed NSStackView auto-sizing issues with explicit width constraints

## Test Plan

- [x] Groups display with correct combined names
- [x] Chevron expands/collapses to show members
- [x] Individual member volume sliders work
- [x] Clicking group card sets it as active
- [x] Hotkeys control group volume when group is selected
- [x] Card widths align perfectly between groups and individuals
- [x] Ungroup button enables when groups are selected

## Screenshots

Groups are displayed as primary cards with expandable member controls, maintaining the liquid glass aesthetic while adopting Sonos-style grouping logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)