### PR TITLE
Fix individual speaker volume control within groups

### DIFF
--- a/SonosVolumeController/FEATURES.md
+++ b/SonosVolumeController/FEATURES.md
@@ -15,7 +15,6 @@
 - **Simplify trigger source UI**: Replace radio button list with read-only info display showing the current trigger device. Now that "Any Device" is the default and works well, the selection UI could be streamlined to just show what's active (with option to change in preferences if needed)
 
 ## Bugs
-- **Individual speaker volume controls group volume**: When adjusting volume sliders for individual speakers within an expanded group view, it controls the entire group volume instead of the individual speaker volume. (TODO in MenuBarContentView.swift:1117)
 - **Ungroup not working with group checkboxes**: Selecting a group via its checkbox and clicking "Ungroup Selected" shows "No grouped speakers selected" error. Issue: group cards use group.id (coordinator UUID) but ungroupSelected() looks for device names.
 - **Speakers list spacing**: Adjust spacing/layout in the speakers section of the menu bar popover
 

--- a/SonosVolumeController/Sources/MenuBarContentView.swift
+++ b/SonosVolumeController/Sources/MenuBarContentView.swift
@@ -1114,10 +1114,9 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         }
 
         let volume = Int(sender.doubleValue)
-        // TODO: Need to implement per-device volume control within groups
-        // For now, this sets the selected device volume
-        appDelegate?.sonosController.selectDevice(name: device.name)
-        appDelegate?.sonosController.setVolume(volume)
+        // Set individual speaker volume within the group
+        // This uses RenderingControl service directly, bypassing group volume logic
+        appDelegate?.sonosController.setIndividualVolume(device: device, volume: volume)
     }
 
     private func updateUngroupButton() {

--- a/SonosVolumeController/Sources/SonosController.swift
+++ b/SonosVolumeController/Sources/SonosController.swift
@@ -653,6 +653,20 @@ class SonosController: @unchecked Sendable {
         }
     }
 
+    /// Set volume for a specific device, bypassing group logic
+    /// Used for controlling individual speakers within a group
+    /// - Parameters:
+    ///   - device: The specific device to control
+    ///   - volume: Volume level (0-100)
+    func setIndividualVolume(device: SonosDevice, volume: Int) {
+        let clampedVolume = max(0, min(100, volume))
+        print("🎚️ setIndividualVolume(\(clampedVolume)) for \(device.name)")
+
+        // Directly set volume using RenderingControl (not GroupRenderingControl)
+        // This works even when the device is part of a group
+        sendSonosCommand(to: device, action: "SetVolume", arguments: ["DesiredVolume": String(clampedVolume)])
+    }
+
     func toggleMute() {
         guard let device = _selectedDevice else {
             print("No Sonos device selected")


### PR DESCRIPTION
## Summary
Fixes the bug where adjusting volume sliders for individual speakers within an expanded group view would control the entire group volume instead of just that specific speaker.

## Changes
- **SonosController.swift**: Added `setIndividualVolume(device:volume:)` method that directly uses the RenderingControl service to set volume for any device, bypassing the group volume logic
- **MenuBarContentView.swift**: Updated `memberVolumeChanged()` to call the new `setIndividualVolume()` method instead of temporarily selecting the device and calling `setVolume()`
- **FEATURES.md**: Removed this bug from the Bugs section

## Technical Details
The previous implementation would:
1. Select the device: `selectDevice(name: device.name)`
2. Call `setVolume(volume)` which has logic to detect if the device is in a group
3. If in a group, redirect to `setGroupVolume()` - affecting all speakers

The new implementation:
- Calls `sendSonosCommand()` directly with the RenderingControl service
- According to Sonos API docs: "Individual volume commands can go to any member"
- This allows controlling individual speaker volumes even when they're part of a group

## Testing
- Build successful ✅
- Ready for testing with grouped speakers

🤖 Generated with [Claude Code](https://claude.com/claude-code)