### PR TITLE
Enhancement: Add star buttons to clarify speaker card interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hierarchical group UI with expandable member controls - groups display as primary cards with drill-down capability to control individual speakers within groups (PR #27)
 
 ### Changed
-- Fixed checkbox vs. card click confusion by adding explicit star buttons to set default speaker/group - eliminates accidental clicks between selecting for grouping vs setting as default
+- Fixed checkbox vs. card click confusion by adding explicit star buttons to set default speaker/group - eliminates accidental clicks between selecting for grouping vs setting as default (PR #34)
 - Simplified UI by streamlining trigger display and preferences window - replaced radio button list with read-only display, removed redundant Audio Devices and Sonos tabs from preferences (PR #32)
 - Changed default hotkeys to Cmd+Shift+9/0 for better ergonomics (PR #20)
 - Fixed hotkeys not working in installed app - reverted to F11/F12 defaults, fixed CGEventFlags conversion, added network entitlements, improved permission flow with auto-restart (PR #22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hierarchical group UI with expandable member controls - groups display as primary cards with drill-down capability to control individual speakers within groups (PR #27)
 
 ### Changed
+- Fixed checkbox vs. card click confusion by adding explicit star buttons to set default speaker/group - eliminates accidental clicks between selecting for grouping vs setting as default
 - Simplified UI by streamlining trigger display and preferences window - replaced radio button list with read-only display, removed redundant Audio Devices and Sonos tabs from preferences (PR #32)
 - Changed default hotkeys to Cmd+Shift+9/0 for better ergonomics (PR #20)
 - Fixed hotkeys not working in installed app - reverted to F11/F12 defaults, fixed CGEventFlags conversion, added network entitlements, improved permission flow with auto-restart (PR #22)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,6 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
-- **Checkbox vs. card click confusion fix** (branch: enhancement/clarify-speaker-interactions, @austinbjohnson)
-
 
 ---
 
@@ -31,7 +29,6 @@ _Issues that break core functionality. Must fix immediately._
 - **Individual speaker volume controls group volume**: When adjusting volume sliders for individual speakers within an expanded group view, it controls the entire group volume instead of the individual speaker volume. The `memberVolumeChanged` method exists but needs proper implementation using RenderingControl service for individual speaker adjustments. (MenuBarContentView.swift:1235-1245)
 
 ### UX Critical
-- **Checkbox vs. card click confusion**: Speaker cards have dual interaction modes - clicking card selects default speaker, clicking checkbox selects for grouping. Frequently causes mistakes between these two actions. Add explicit "Set as Default" button/icon (e.g., star) to disambiguate. (MenuBarContentView.swift:1061-1073, 1216-1233) [Added by claudeCode]
 
 ### Architecture Critical
 - **Thread safety violations with @unchecked Sendable**: SonosController marked @unchecked Sendable but has extensive mutable state (`devices`, `groups` arrays) accessed from multiple threads without proper synchronization. Risk of data races and crashes. Need to either convert to `actor` or add proper locking. (SonosController.swift:4-78) [Added by claudeCode]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,8 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
+- **Checkbox vs. card click confusion fix** (branch: enhancement/clarify-speaker-interactions, @austinbjohnson)
+
 
 ---
 
@@ -26,8 +28,6 @@ _When starting work on a task, add it here with your branch name and username to
 _Issues that break core functionality. Must fix immediately._
 
 ### Bugs
-- **Header visibility after speakers load**: After speakers are populated in the popover, the header section ("Active" status and speaker name) may not be visible until the popover is reopened or the view is interacted with. The Y coordinate of the header label becomes incorrect (~726px instead of ~40-60px) after population. Scroll-to-top commands don't fix the issue, suggesting a deeper layout coordinate system problem. (MenuBarContentView.swift:673-833) [Added by claudeCode]
-
 - **Individual speaker volume controls group volume**: When adjusting volume sliders for individual speakers within an expanded group view, it controls the entire group volume instead of the individual speaker volume. The `memberVolumeChanged` method exists but needs proper implementation using RenderingControl service for individual speaker adjustments. (MenuBarContentView.swift:1235-1245)
 
 ### UX Critical

--- a/SonosVolumeController_icon.icon/icon.json
+++ b/SonosVolumeController_icon.icon/icon.json
@@ -1,0 +1,17 @@
+{
+  "fill" : {
+    "linear-gradient" : [
+      "display-p3:0.38403,0.64839,1.00000,1.00000",
+      "extended-srgb:0.00000,0.53333,1.00000,1.00000"
+    ]
+  },
+  "groups" : [
+
+  ],
+  "supported-platforms" : {
+    "circles" : [
+      "watchOS"
+    ],
+    "squares" : "shared"
+  }
+}


### PR DESCRIPTION
## Summary
- Added explicit star button (⭐) to set default speaker/group 
- Removed confusing card body click gestures that caused frequent user mistakes
- Clear visual separation: star = set as default, checkbox = select for grouping

## Problem Solved
Previously, speaker cards had dual interaction modes that confused users:
- Clicking the card body set it as default speaker
- Clicking the checkbox selected it for grouping
Users frequently made mistakes between these two actions (P0 UX Critical issue).

## Solution
- Added star icon button on left side of each card to explicitly set as default
- Yellow filled star shows current default, gray unfilled for others  
- Card body no longer clickable - display only
- Clear tooltips: "Set as default speaker" or "Default speaker"
- Both speaker and group cards have star buttons
- Maintains liquid glass design for macOS 26 Tahoe

## Test Plan
- [x] Star button appears on all speaker cards
- [x] Star button appears on all group cards
- [x] Clicking star sets speaker/group as default
- [x] Yellow star shows for default, gray for others
- [x] Tooltips appear on hover
- [x] Checkbox still works for grouping/ungrouping
- [x] Card body no longer triggers default selection
- [x] App builds and runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)