### PR TITLE
Enhancement: Simplify active speaker concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Audio trigger source dropdown in Preferences window for selecting which audio device activates Sonos control (PR #37)
 
 ### Changed
-- Simplified active speaker concept - replaced manual "default speaker" configuration with automatic "last active speaker" tracking, app now remembers what you were last controlling, replaced yellow star button with blue dot indicator, hover-only checkboxes for cleaner UI
+- Simplified active speaker concept - replaced manual "default speaker" configuration with automatic "last active speaker" tracking, app now remembers what you were last controlling, replaced yellow star button with blue dot indicator, hover-only checkboxes for cleaner UI (PR #40)
 - Fixed checkbox vs. card click confusion by adding explicit star buttons to set default speaker/group - eliminates accidental clicks between selecting for grouping vs setting as default (PR #34)
 - Simplified UI by streamlining trigger display and preferences window - replaced radio button list with read-only display, removed redundant Audio Devices and Sonos tabs from preferences (PR #32)
 - Changed default hotkeys to Cmd+Shift+9/0 for better ergonomics (PR #20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Audio trigger source dropdown in Preferences window for selecting which audio device activates Sonos control (PR #37)
 
 ### Changed
+- Simplified active speaker concept - replaced manual "default speaker" configuration with automatic "last active speaker" tracking, app now remembers what you were last controlling, replaced yellow star button with blue dot indicator, hover-only checkboxes for cleaner UI
 - Fixed checkbox vs. card click confusion by adding explicit star buttons to set default speaker/group - eliminates accidental clicks between selecting for grouping vs setting as default (PR #34)
 - Simplified UI by streamlining trigger display and preferences window - replaced radio button list with read-only display, removed redundant Audio Devices and Sonos tabs from preferences (PR #32)
 - Changed default hotkeys to Cmd+Shift+9/0 for better ergonomics (PR #20)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,8 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
+- **Simplify active speaker concept** (branch: enhancement/simplify-active-speaker, @austinbjohnson)
+
 ---
 
 ## App Store Readiness

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,6 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
-- **Simplify active speaker concept** (branch: enhancement/simplify-active-speaker, @austinbjohnson)
-
 ---
 
 ## App Store Readiness
@@ -47,8 +45,6 @@ _Major friction points impacting usability, significant missing features, or imp
 - **Merge multiple groups**: Allow merging two or more existing groups into a single larger group. Currently can only create new groups from ungrouped speakers.
 
 ### Enhancements
-- **Simplify active speaker concept**: Remove "default speaker" concept and use "last active speaker" instead. On app launch, select the last speaker that was actively used (not a configured default). This makes the behavior more intuitive - the app remembers what you were last controlling. Remove default speaker setting from Preferences. (main.swift, PreferencesWindow.swift, AppSettings.swift)
-
 - **Real-time trigger device display update**: Trigger device display in menu bar popover only updates when popover is reopened. Add real-time notification/observer pattern so display updates immediately when changed in Preferences without requiring popover close/reopen. (MenuBarContentView.swift:1667, MenuBarPopover.swift:59) [Added by claudeCode]
 
 - **No visual indication when app disabled**: Menu bar icon doesn't change when app is in "Standby" mode (settings.enabled = false). Can't tell at a glance if hotkeys will work. Consider dimming icon or adding slash overlay. (main.swift:32-67) [Added by claudeCode]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,8 @@ _When starting work on a task, add it here with your branch name and username to
 _Issues that break core functionality. Must fix immediately._
 
 ### Bugs
+- **Hotkeys not working in clean install - no permission feedback**: On clean install, hotkeys produce system "bonk" sound but don't control volume. User gets no indication that accessibility permission is missing or that hotkeys are disabled. Need better permission status visibility and actionable feedback when hotkeys fail. Current permission check only shows alert on first launch, but doesn't help diagnose why hotkeys aren't working after that. Consider: (1) Show permission status in menu bar popover or Preferences, (2) Add HUD notification when hotkeys pressed without required permissions, (3) Add "Test Hotkeys" button in Preferences to verify they're working. (main.swift:193-243, VolumeKeyMonitor.swift)
+
 - **Cannot select collapsed group for ungrouping**: When a group is collapsed, clicking the checkbox does not allow selecting it for the "Ungroup Selected" action. Must expand group first to select members. Should be able to select collapsed groups for ungrouping. (MenuBarContentView.swift)
 
 - **Line-in audio source stops when grouping**: When grouping a speaker playing line-in audio with another speaker, the audio pauses briefly, plays for one second after grouping completes, then cuts out entirely. The Sonos app shows the line-in source is no longer active for the group. This is likely because the non-line-in speaker becomes the group coordinator and line-in sources cannot be shared across groups (device-specific limitation). Need to detect line-in sources and either: (1) make the line-in speaker the coordinator, or (2) warn user before grouping. (SonosController.swift:937-998)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,8 @@ _When starting work on a task, add it here with your branch name and username to
 _Issues that break core functionality. Must fix immediately._
 
 ### Bugs
+- **Popover height not calculated correctly on initial display**: When popover first opens, height calculation doesn't account for all speakers/groups, resulting in tiny scroll area. Height is correct after clicking a speaker (triggers resize). The issue is that initial height calculation in populateSpeakers() doesn't properly account for expanded groups or total card count. Need to ensure updatePopoverSize() is called after all cards are added with correct height calculation. (MenuBarContentView.swift - populateSpeakers, updatePopoverSize, calculateCardsHeight)
+
 - **Hotkeys not working in clean install - no permission feedback**: On clean install, hotkeys produce system "bonk" sound but don't control volume. User gets no indication that accessibility permission is missing or that hotkeys are disabled. Need better permission status visibility and actionable feedback when hotkeys fail. Current permission check only shows alert on first launch, but doesn't help diagnose why hotkeys aren't working after that. Consider: (1) Show permission status in menu bar popover or Preferences, (2) Add HUD notification when hotkeys pressed without required permissions, (3) Add "Test Hotkeys" button in Preferences to verify they're working. (main.swift:193-243, VolumeKeyMonitor.swift)
 
 - **Cannot select collapsed group for ungrouping**: When a group is collapsed, clicking the checkbox does not allow selecting it for the "Ungroup Selected" action. Must expand group first to select members. Should be able to select collapsed groups for ungrouping. (MenuBarContentView.swift)

--- a/SonosVolumeController/Sources/MenuBarContentView.swift
+++ b/SonosVolumeController/Sources/MenuBarContentView.swift
@@ -393,19 +393,15 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
 
         let isExpanded = expandedGroups.contains(group.id)
 
-        // Star button to set as default
-        let starButton = NSButton()
-        starButton.image = NSImage(systemSymbolName: isActive ? "star.fill" : "star",
-                                    accessibilityDescription: isActive ? "Default group" : "Set as default")
-        starButton.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 16, weight: .medium)
-        starButton.contentTintColor = isActive ? .systemYellow : .tertiaryLabelColor
-        starButton.isBordered = false
-        starButton.bezelStyle = .inline
-        starButton.target = self
-        starButton.action = #selector(selectGroup(_:))
-        starButton.identifier = NSUserInterfaceItemIdentifier(group.id)
-        starButton.toolTip = isActive ? "Default group" : "Set as default group"
-        starButton.translatesAutoresizingMaskIntoConstraints = false
+        // Active indicator (blue dot) - non-interactive visual indicator
+        let activeIndicator = NSView()
+        if isActive {
+            activeIndicator.wantsLayer = true
+            activeIndicator.layer?.backgroundColor = NSColor.systemBlue.cgColor
+            activeIndicator.layer?.cornerRadius = 4
+            activeIndicator.toolTip = "Currently active"
+        }
+        activeIndicator.translatesAutoresizingMaskIntoConstraints = false
 
         // Chevron for expansion - make it a button so it's separately clickable
         let chevronButton = NSButton()
@@ -445,24 +441,29 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         checkbox.translatesAutoresizingMaskIntoConstraints = false
         checkbox.toolTip = "Select for ungrouping"
 
-        // Card identifier for tracking (no longer needed for click gesture)
+        // Card identifier for tracking
         card.identifier = NSUserInterfaceItemIdentifier(group.id)
 
-        card.addSubview(starButton)
+        // Add click gesture to card (since we removed the interactive star button)
+        let cardClick = NSClickGestureRecognizer(target: self, action: #selector(selectGroup(_:)))
+        cardClick.delegate = self
+        card.addGestureRecognizer(cardClick)
+
+        card.addSubview(activeIndicator)
         card.addSubview(chevronButton)
         card.addSubview(icon)
         card.addSubview(nameLabel)
         card.addSubview(checkbox)
 
         NSLayoutConstraint.activate([
-            // Star button on the left
-            starButton.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 8),
-            starButton.centerYAnchor.constraint(equalTo: card.centerYAnchor),
-            starButton.widthAnchor.constraint(equalToConstant: 24),
-            starButton.heightAnchor.constraint(equalToConstant: 24),
+            // Active indicator (blue dot) on the left
+            activeIndicator.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 8),
+            activeIndicator.centerYAnchor.constraint(equalTo: card.centerYAnchor),
+            activeIndicator.widthAnchor.constraint(equalToConstant: 8),
+            activeIndicator.heightAnchor.constraint(equalToConstant: 8),
 
-            // Chevron after star button
-            chevronButton.leadingAnchor.constraint(equalTo: starButton.trailingAnchor, constant: 6),
+            // Chevron after active indicator
+            chevronButton.leadingAnchor.constraint(equalTo: activeIndicator.trailingAnchor, constant: 8),
             chevronButton.centerYAnchor.constraint(equalTo: card.centerYAnchor),
             chevronButton.widthAnchor.constraint(equalToConstant: 20),
             chevronButton.heightAnchor.constraint(equalToConstant: 20),
@@ -604,19 +605,15 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
             ])
         }
 
-        // Star button to set as default
-        let starButton = NSButton()
-        starButton.image = NSImage(systemSymbolName: isActive ? "star.fill" : "star",
-                                    accessibilityDescription: isActive ? "Default speaker" : "Set as default")
-        starButton.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 16, weight: .medium)
-        starButton.contentTintColor = isActive ? .systemYellow : .tertiaryLabelColor
-        starButton.isBordered = false
-        starButton.bezelStyle = .inline
-        starButton.target = self
-        starButton.action = #selector(selectSpeaker(_:))
-        starButton.identifier = NSUserInterfaceItemIdentifier(device.name)
-        starButton.toolTip = isActive ? "Default speaker" : "Set as default speaker"
-        starButton.translatesAutoresizingMaskIntoConstraints = false
+        // Active indicator (blue dot) - non-interactive visual indicator
+        let activeIndicator = NSView()
+        if isActive {
+            activeIndicator.wantsLayer = true
+            activeIndicator.layer?.backgroundColor = NSColor.systemBlue.cgColor
+            activeIndicator.layer?.cornerRadius = 4
+            activeIndicator.toolTip = "Currently active"
+        }
+        activeIndicator.translatesAutoresizingMaskIntoConstraints = false
 
         // Speaker icon
         let icon = NSImageView()
@@ -684,20 +681,25 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
 
         let leadingOffset: CGFloat = (isInGroup && !isGroupCoordinator) ? 20 : 8
 
-        card.addSubview(starButton)
+        // Add click gesture to card (since we removed the interactive star button)
+        let cardClick = NSClickGestureRecognizer(target: self, action: #selector(selectSpeaker(_:)))
+        cardClick.delegate = self
+        card.addGestureRecognizer(cardClick)
+
+        card.addSubview(activeIndicator)
         card.addSubview(icon)
         card.addSubview(textStack)
         card.addSubview(checkbox)
 
         NSLayoutConstraint.activate([
-            // Star button on the left
-            starButton.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: leadingOffset),
-            starButton.centerYAnchor.constraint(equalTo: card.centerYAnchor),
-            starButton.widthAnchor.constraint(equalToConstant: 24),
-            starButton.heightAnchor.constraint(equalToConstant: 24),
+            // Active indicator (blue dot) on the left
+            activeIndicator.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: leadingOffset),
+            activeIndicator.centerYAnchor.constraint(equalTo: card.centerYAnchor),
+            activeIndicator.widthAnchor.constraint(equalToConstant: 8),
+            activeIndicator.heightAnchor.constraint(equalToConstant: 8),
 
-            // Icon follows the star button
-            icon.leadingAnchor.constraint(equalTo: starButton.trailingAnchor, constant: 6),
+            // Icon follows the active indicator
+            icon.leadingAnchor.constraint(equalTo: activeIndicator.trailingAnchor, constant: 8),
             icon.centerYAnchor.constraint(equalTo: card.centerYAnchor),
             icon.widthAnchor.constraint(equalToConstant: 20),
             icon.heightAnchor.constraint(equalToConstant: 20),
@@ -1026,7 +1028,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         icon.translatesAutoresizingMaskIntoConstraints = false
 
         // Welcome text
-        let text = NSTextField(labelWithString: "Welcome! Select your default speaker below to get started.")
+        let text = NSTextField(labelWithString: "Welcome! Click any speaker below to start controlling it with volume hotkeys.")
         text.font = .systemFont(ofSize: 12, weight: .medium)
         text.textColor = .labelColor
         text.alignment = .left

--- a/SonosVolumeController/Sources/MenuBarContentView.swift
+++ b/SonosVolumeController/Sources/MenuBarContentView.swift
@@ -439,7 +439,8 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         checkbox.identifier = NSUserInterfaceItemIdentifier(group.id)
         checkbox.translatesAutoresizingMaskIntoConstraints = false
         checkbox.toolTip = "Select for ungrouping"
-        checkbox.isHidden = true  // Hidden by default, shown on hover
+        // Hidden by default, shown on hover (unless already checked)
+        checkbox.isHidden = (checkbox.state != .on)
 
         // Card identifier for tracking
         card.identifier = NSUserInterfaceItemIdentifier(group.id)
@@ -488,7 +489,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
             nameLabel.centerYAnchor.constraint(equalTo: card.centerYAnchor),
             nameLabel.trailingAnchor.constraint(equalTo: checkbox.leadingAnchor, constant: -10),
 
-            // Checkbox stays on right
+            // Checkbox stays on right (aligned with speaker checkboxes)
             checkbox.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -12),
             checkbox.centerYAnchor.constraint(equalTo: card.centerYAnchor),
 
@@ -681,7 +682,8 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         checkbox.identifier = NSUserInterfaceItemIdentifier(device.name)
         checkbox.translatesAutoresizingMaskIntoConstraints = false
         checkbox.toolTip = "Select for grouping"
-        checkbox.isHidden = true  // Hidden by default, shown on hover
+        // Hidden by default, shown on hover (unless already checked)
+        checkbox.isHidden = (checkbox.state != .on)
 
         // Card identifier for tracking
         card.identifier = NSUserInterfaceItemIdentifier(device.name)
@@ -1868,7 +1870,10 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         super.mouseExited(with: event)
         if let trackingArea = event.trackingArea,
            let checkbox = trackingArea.userInfo?["checkbox"] as? NSButton {
-            checkbox.isHidden = true
+            // Keep checkbox visible if it's checked (selected for grouping/ungrouping)
+            if checkbox.state != .on {
+                checkbox.isHidden = true
+            }
         }
     }
 }

--- a/SonosVolumeController/Sources/MenuBarContentView.swift
+++ b/SonosVolumeController/Sources/MenuBarContentView.swift
@@ -153,7 +153,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         container.addSubview(statusLabel)
 
         // Speaker name - large and prominent
-        let currentSpeaker = appDelegate?.settings.selectedSonosDevice ?? "No Speaker"
+        let currentSpeaker = appDelegate?.settings.lastActiveSpeaker ?? "No Speaker"
         speakerNameLabel = NSTextField(labelWithString: currentSpeaker)
         speakerNameLabel.font = .systemFont(ofSize: 22, weight: .semibold)
         speakerNameLabel.textColor = .labelColor
@@ -763,7 +763,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
             return
         }
 
-        let currentSpeaker = appDelegate?.settings.selectedSonosDevice
+        let currentSpeaker = appDelegate?.settings.lastActiveSpeaker
         let groups = controller.cachedDiscoveredGroups
         let devices = controller.cachedDiscoveredDevices
 
@@ -1257,7 +1257,8 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         Task {
             await appDelegate?.sonosController.selectDevice(name: deviceName)
         }
-        appDelegate?.settings.selectedSonosDevice = deviceName
+        // Track this speaker as last active
+        appDelegate?.settings.trackSpeakerActivity(deviceName)
 
         speakerNameLabel.stringValue = deviceName
         populateSpeakers()
@@ -1430,7 +1431,8 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
             Task {
                 await appDelegate?.sonosController.selectDevice(name: group.coordinator.name)
             }
-            appDelegate?.settings.selectedSonosDevice = group.coordinator.name
+            // Track this group as last active
+            appDelegate?.settings.trackSpeakerActivity(group.coordinator.name)
 
             // Update UI to show group name
             speakerNameLabel.stringValue = group.name
@@ -1685,7 +1687,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
                     self.populateSpeakers()
 
                     // Update volume slider if one of the grouped speakers was selected
-                    if let selectedDevice = self.appDelegate?.settings.selectedSonosDevice,
+                    if let selectedDevice = self.appDelegate?.settings.lastActiveSpeaker,
                        devices.contains(where: { $0.name == selectedDevice }) {
                         self.updateVolumeFromSonos()
                     }
@@ -1818,7 +1820,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         // Discovery completed if we're calling refresh
         isLoadingDevices = false
 
-        speakerNameLabel.stringValue = appDelegate?.settings.selectedSonosDevice ?? "No Speaker"
+        speakerNameLabel.stringValue = appDelegate?.settings.lastActiveSpeaker ?? "No Speaker"
         updateStatus()
         updateTriggerDeviceLabel()
         populateSpeakers()

--- a/SonosVolumeController/Sources/MenuBarContentView.swift
+++ b/SonosVolumeController/Sources/MenuBarContentView.swift
@@ -423,8 +423,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         icon.translatesAutoresizingMaskIntoConstraints = false
 
         // Group name
-        let displayName = isActive ? "\(group.name) (Default)" : group.name
-        let nameLabel = NSTextField(labelWithString: displayName)
+        let nameLabel = NSTextField(labelWithString: group.name)
         nameLabel.font = .systemFont(ofSize: 13, weight: isActive ? .semibold : .medium)
         nameLabel.textColor = isActive ? .labelColor : .labelColor
         nameLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -624,10 +623,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         icon.translatesAutoresizingMaskIntoConstraints = false
 
         // Build display name with group info
-        var displayName = device.name
-        if isActive {
-            displayName += " (Default)"
-        }
+        let displayName = device.name
 
         // Create a stack for name + group info
         let textStack = NSStackView()

--- a/SonosVolumeController/Sources/SonosController.swift
+++ b/SonosVolumeController/Sources/SonosController.swift
@@ -524,7 +524,8 @@ actor SonosController {
         _selectedDevice = devices.first { $0.name == name }
         updateCachedValues() // Update thread-safe copies
         if let device = _selectedDevice {
-            settings.selectedSonosDevice = device.name
+            // Track this device as last active
+            settings.trackSpeakerActivity(device.name)
 
             var info = "✅ Selected: \(device.name)"
             if device.channelMapSet != nil {

--- a/SonosVolumeController/Sources/main.swift
+++ b/SonosVolumeController/Sources/main.swift
@@ -107,14 +107,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             await sonosController.discoverDevices { [weak self] in
                 guard let self = self else { return }
 
-                // Auto-select default speaker AFTER topology is loaded
+                // Auto-select last active speaker AFTER topology is loaded
                 Task { @MainActor in
-                    if !self.settings.selectedSonosDevice.isEmpty {
-                        print("🎵 Auto-selecting default speaker (after topology loaded): \(self.settings.selectedSonosDevice)")
-                        await self.sonosController.selectDevice(name: self.settings.selectedSonosDevice)
+                    if !self.settings.lastActiveSpeaker.isEmpty {
+                        print("🎵 Restoring last active speaker (after topology loaded): \(self.settings.lastActiveSpeaker)")
+                        await self.sonosController.selectDevice(name: self.settings.lastActiveSpeaker)
 
                         // Fetch and sync current volume from the selected speaker
-                        print("🔊 Fetching current volume from default speaker...")
+                        print("🔊 Fetching current volume from last active speaker...")
                         await self.sonosController.getVolume { @Sendable volume in
                             print("🔊 Initial volume: \(volume)%")
                             // Post notification to update UI
@@ -127,7 +127,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                             }
                         }
                     } else {
-                        print("⚠️ No default speaker configured")
+                        print("🆕 No previous speaker - will set after first selection")
 
                         // First launch - show popover to guide user to select a speaker
                         print("👋 First launch detected - showing onboarding popover")


### PR DESCRIPTION
## Summary
- Replaced manual "default speaker" configuration with automatic "last active speaker" tracking
- App now automatically remembers the last speaker you controlled without requiring manual configuration
- Simplified UI: replaced interactive yellow star button with passive blue dot indicator
- Cleaner interface: hover-only checkboxes for grouping, removed "(Default)" text suffix
- Consistent alphabetical sorting for predictable list ordering

## Changes

### Core Behavior
- **AppSettings.swift**: Added `lastActiveSpeaker` property and `trackSpeakerActivity()` method, migration logic from old `selectedSonosDevice`
- **SonosController.swift**: Tracks speaker activity on device selection
- **main.swift**: Restores last active speaker on launch instead of "default speaker"
- **MenuBarContentView.swift**: Tracks activity on all speaker interactions (slider, card clicks)

### UI/UX Improvements
- Replaced yellow star button with 8pt blue dot indicator (non-interactive, passive)
- Updated welcome banner copy to reflect "last active" concept
- Implemented hover-only checkboxes (visible on hover or when checked)
- Fixed sorting to be purely alphabetical (no pinning active speaker)
- Removed "(Default)" text suffix from speaker/group names

## Migration
- Seamless migration: existing `selectedSonosDevice` values automatically migrated to `lastActiveSpeaker`
- No user action required, preferences preserved

## Follow-up
- Added P0 bug to ROADMAP: Popover height calculation needs fix for initial display with multiple groups

## Test Plan
- [x] Build succeeds with `swift build -c release`
- [x] App launches and discovers speakers
- [x] Blue dot appears on last active speaker
- [x] Clicking different speaker updates blue dot
- [x] Checkboxes only visible on hover (except when checked)
- [x] Sorting is consistently alphabetical
- [x] Migration works for existing users
- [x] First-time users see onboarding (no last active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)