### PR TITLE
Fix: Popover height calculation on initial display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed hotkeys not working in installed app - reverted to F11/F12 defaults, fixed CGEventFlags conversion, added network entitlements, improved permission flow with auto-restart (PR #22)
 
 ### Fixed
+- Popover height calculation on initial display - fixed tiny scroll area bug by forcing Auto Layout to complete before measuring card heights, popover now displays with correct height on first open
 - Real-time group volume slider synchronization - member sliders within expanded groups now update immediately when adjusting group volume, with smooth animations and visual feedback via pulsing connection lines (PR #39)
 - Enhanced group volume controls with bidirectional synchronization - individual speaker sliders now correctly display and control their own volumes (not group volume), group slider updates when individual speakers change, smooth animations throughout (PR #38)
 - Thread safety violations with @unchecked Sendable - converted SonosController to actor with proper async/await patterns, eliminated data race risks (PR #35)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,8 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
+- **Fix popover height calculation on initial display** (branch: bug/popover-height-calculation, @austinbjohnson)
+
 ---
 
 ## App Store Readiness

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,6 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
-- **Fix popover height calculation on initial display** (branch: bug/popover-height-calculation, @austinbjohnson)
-
 ---
 
 ## App Store Readiness
@@ -27,8 +25,6 @@ _When starting work on a task, add it here with your branch name and username to
 _Issues that break core functionality. Must fix immediately._
 
 ### Bugs
-- **Popover height not calculated correctly on initial display**: When popover first opens, height calculation doesn't account for all speakers/groups, resulting in tiny scroll area. Height is correct after clicking a speaker (triggers resize). The issue is that initial height calculation in populateSpeakers() doesn't properly account for expanded groups or total card count. Need to ensure updatePopoverSize() is called after all cards are added with correct height calculation. (MenuBarContentView.swift - populateSpeakers, updatePopoverSize, calculateCardsHeight)
-
 - **Hotkeys not working in clean install - no permission feedback**: On clean install, hotkeys produce system "bonk" sound but don't control volume. User gets no indication that accessibility permission is missing or that hotkeys are disabled. Need better permission status visibility and actionable feedback when hotkeys fail. Current permission check only shows alert on first launch, but doesn't help diagnose why hotkeys aren't working after that. Consider: (1) Show permission status in menu bar popover or Preferences, (2) Add HUD notification when hotkeys pressed without required permissions, (3) Add "Test Hotkeys" button in Preferences to verify they're working. (main.swift:193-243, VolumeKeyMonitor.swift)
 
 - **Line-in audio source stops when grouping**: When grouping a speaker playing line-in audio with another speaker, the audio pauses briefly, plays for one second after grouping completes, then cuts out entirely. The Sonos app shows the line-in source is no longer active for the group. This is likely because the non-line-in speaker becomes the group coordinator and line-in sources cannot be shared across groups (device-specific limitation). Need to detect line-in sources and either: (1) make the line-in speaker the coordinator, or (2) warn user before grouping. (SonosController.swift:937-998)

--- a/SonosVolumeController/Sources/MenuBarContentView.swift
+++ b/SonosVolumeController/Sources/MenuBarContentView.swift
@@ -863,9 +863,14 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
             scrollView.reflectScrolledClipView(scrollView.contentView)
         }
 
-        // Update popover size after initial populate (with delay to ensure layout is complete)
+        // Update popover size after initial populate
+        // Force layout to complete before calculating heights
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
+
+            // Force layout on all card subviews to ensure heights are calculated
+            self.speakerCardsContainer.layoutSubtreeIfNeeded()
+            self.containerView.layoutSubtreeIfNeeded()
 
             // Force scroll to top again after layout
             if let scrollView = self.speakerCardsContainer.enclosingScrollView {
@@ -1723,6 +1728,9 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
     // MARK: - Dynamic Sizing
 
     private func calculateContentHeight() -> CGFloat {
+        // Force layout to ensure all card frames are calculated
+        speakerCardsContainer.layoutSubtreeIfNeeded()
+
         // Calculate total height of speaker cards
         var cardsHeight: CGFloat = 0
         for view in speakerCardsContainer.arrangedSubviews {


### PR DESCRIPTION
## Summary
Fixed the popover height calculation bug where the popover displayed with a tiny scroll area on initial open. The popover now correctly calculates and displays the proper height from the start.

## Problem
When the popover first opened with multiple speakers/groups, the height calculation was incorrect, resulting in a tiny scroll area. The height would correct itself after clicking a speaker (which triggered a resize).

## Root Cause
The height was being calculated **before** Auto Layout finished resolving constraints on the speaker cards. When `calculateContentHeight()` read `view.frame.height`, the frames were still at their initial/temporary values (often 0), resulting in an incorrect total height calculation.

## Solution
Added `layoutSubtreeIfNeeded()` calls to force Auto Layout to resolve all pending constraints before measuring heights:

1. **In `calculateContentHeight()`** (Line 1731):
   - Forces layout on `speakerCardsContainer` before measuring card heights
   - Ensures accurate `frame.height` values

2. **In `populateSpeakers()`** (Line 869-872):
   - Forces layout on both `speakerCardsContainer` and `containerView` before calling `updatePopoverSize()`
   - Ensures initial popover display has correct height

## Changes
- **MenuBarContentView.swift**: Added layout forcing in two key locations
- Removed from P0 bugs in ROADMAP.md
- Added to CHANGELOG.md under "Fixed"

## Testing
- [x] Build succeeds with `swift build -c release`
- [x] Popover displays with correct height on first open
- [x] Multiple groups + speakers display correctly
- [x] Expanded groups account for proper height
- [x] Scroll area is correctly sized (not tiny)
- [x] Clicking speakers still works and maintains correct height
- [x] Group expand/collapse animations work smoothly

## Edge Cases Tested
- Welcome banner visible (first launch) vs hidden
- Single speaker vs many speakers
- Collapsed groups vs expanded groups
- Mixed content (groups + ungrouped speakers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)