### PR TITLE
Fix: Accessibility permission feedback system (Phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Core code lives in `SonosVolumeController/Sources`, with infrastructure services under `Infrastructure/`, input monitors in `VolumeKeyMonitor.swift` and `AudioDeviceMonitor.swift`, and UI surfaces in `MenuBarContentView.swift`, `MenuBarPopover.swift`, and `PreferencesWindow.swift`. Packaging assets and entitlements sit in `Resources/`. Docs such as `docs/sonos-api/` hold Sonos protocol notes; keep new research there for future contributors.
+
+## Build, Test, and Development Commands
+`swift run` from `SonosVolumeController/` provides the fastest feedback loop; run `pkill SonosVolumeController` first to avoid duplicate menu bar icons. `swift build -c release` validates optimized builds. Use `./build-app.sh` to bundle locally and `./build-app.sh --install` to copy into `/Applications` and relaunch the production build.
+
+## Coding Style & Naming Conventions
+Code targets Swift 6 with four-space indentation, `CamelCase` types, `lowerCamelCase` members, and trailing commas retained for multi-line literals. Maintain actor isolation (`@MainActor`, `SonosController` actor) and group extensions by role. Logging should stay terse; reuse the existing emoji-prefixed style only when expanding a subsystem that already uses it.
+
+## Testing Guidelines
+Automated tests are not yet wired, so document manual coverage in PRs: `swift run`, select a speaker, adjust volume, and confirm HUD updates through network hiccups. Monitor console output for `SonosDevicesDiscovered` and `SonosNetworkError`. If you add XCTest targets, mirror file names (e.g., `SonosControllerTests.swift`) and register them in `Package.swift`.
+
+## Commit & Pull Request Guidelines
+Commits stay scoped and imperative. When produced with an AI agent, follow the template `Feature: Short description`, add `🤖 Generated with [Claude Code](https://claude.com/claude-code)`, and include `Co-Authored-By: Claude <noreply@anthropic.com>`. PRs must summarize behavioral changes, list manual test commands, attach screenshots for UI updates, and link related ROADMAP items. Update `CHANGELOG.md` before opening the PR (no number) and again after GitHub assigns one.
+
+## AI Collaboration Workflow
+Start every effort with `/start <descriptor>` to sync ROADMAP.md, branch correctly, and log ownership; end with `/finish` to run the completion checklist. Break multi-step work with the TodoWrite tool, marking entries in progress or complete immediately. Launch specialized agents proactively: `architecture-advisor` for structural decisions, `ux-ui-designer` for menu bar or HUD tweaks, `discovery-documenter`/`requirements-writer`/`ticket-breaker` for product planning, and `/security-review` before merging sensitive changes.
+
+## Security & Configuration Tips
+Grant Accessibility control so volume hotkeys fire, and ensure the Mac shares a subnet with Sonos hardware for multicast discovery. Store credentials via `AppSettings` or keychain helpers—never hardcode secrets. Reinstall via `./build-app.sh --install` when testing login-item behavior or entitlement changes.

--- a/AI_DEV_GUIDE.md
+++ b/AI_DEV_GUIDE.md
@@ -1,0 +1,387 @@
+# AI Developer Collaboration Guide
+
+This guide is for AI assistants (like Claude Code) working on the Sonos Volume Controller project. It covers available tools, agents, commands, and best practices for effective collaboration.
+
+---
+
+## Quick Reference
+
+### Available Slash Commands
+
+**`/start [optional focus area]`**
+- Automated workflow to begin new work
+- Checks for open PRs, returns to main, suggests next tasks from ROADMAP.md
+- Creates feature branch and updates "In Progress" section
+- Presents implementation plan before coding
+
+**`/finish [optional context]`**
+- Checklist to complete current work
+- Guides through PR creation, CHANGELOG/ROADMAP updates
+- Tracks technical debt
+
+**`/security-review [file or directory]`**
+- Reviews code for security vulnerabilities
+- Use proactively before PRs
+
+---
+
+## Available Specialized Agents
+
+### Development & Architecture
+
+**`architecture-advisor`**
+- Use when: Starting new features, completing significant code changes, refactoring
+- Provides: Architectural guidance, design pattern recommendations, dependency analysis
+- Example: After implementing a new service layer or before starting a major feature
+
+**`ux-ui-designer`**
+- Use when: Designing UI, creating wireframes, optimizing UX, accessibility improvements
+- Provides: Design specifications, interaction patterns, user flow optimization
+- Example: Before implementing menu bar UI changes or HUD improvements
+
+**`zapier-zinnia-engineer`**
+- Use when: Working with design system components (not applicable to this Swift project)
+- Note: This agent is for Zapier's React design system - not relevant here
+
+### Product Management (from global CLAUDE.md)
+
+**`discovery-documenter`**
+- Use when: Before/during prototyping to formalize learnings
+- Provides: Problem Discovery and Solution Exploration documents
+- Example: When exploring a new feature like "multi-room scene support"
+
+**`requirements-writer`**
+- Use when: Prototype validated and PRD needed
+- Provides: Formal PRD with press release format
+- Example: After validating an approach for a major feature
+
+**`ticket-breaker`**
+- Use when: PRD finalized and ready for engineering handoff
+- Provides: Sequenced JIRA ticket breakdown
+- Example: Breaking down a complex feature into implementation tasks
+
+**`enterprise-risk-spotter`**
+- Use when: Proactively reviewing features for enterprise concerns
+- Provides: Security, compliance, scalability risk analysis
+- Example: Before implementing network features or data storage
+
+---
+
+## Project-Specific Workflow
+
+### 1. Starting Work
+
+**Always use `/start` command** - it automates:
+1. Checking for open PRs
+2. Returning to main branch
+3. Suggesting prioritized tasks from ROADMAP.md
+4. Creating appropriately named branch
+5. Updating "In Progress" section
+6. Launching appropriate agent if needed
+
+**Branch naming:**
+- Bugs: `bug/descriptive-name`
+- Features: `feature/descriptive-name`
+- Enhancements: `enhancement/descriptive-name`
+
+### 2. During Development
+
+**Use TodoWrite tool for multi-step tasks**
+- Break complex work into trackable steps
+- Mark tasks in_progress/completed as you go
+- Never batch completions - mark done immediately
+
+**Consult Sonos API docs** (`docs/sonos-api/`) before implementing:
+- `volume.md` - Volume control patterns
+- `groups.md` - Group management
+- `upnp-local-api.md` - SOAP API reference
+
+**Testing commands:**
+```bash
+# Quick iteration
+swift run
+
+# Kill and restart
+pkill SonosVolumeController && swift run
+
+# Build .app bundle
+./build-app.sh
+
+# Build and install to /Applications
+./build-app.sh --install
+```
+
+### 3. Completing Work
+
+**Use `/finish` command** - it guides through:
+1. Testing (swift build -c release)
+2. CHANGELOG.md update (without PR number)
+3. ROADMAP.md cleanup (remove from "In Progress" and planned sections)
+4. Commit and push
+5. PR creation with gh pr create
+6. CHANGELOG.md update (add PR number)
+
+**Two-stage CHANGELOG.md update is required:**
+- First: Add entry without PR number before creating PR
+- Second: Add PR number after GitHub assigns it
+
+**Commit message format:**
+```
+Feature: Description
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+---
+
+## Architecture Overview
+
+### Key Components
+
+| File | Responsibility |
+|------|---------------|
+| `main.swift` | App entry point, initialization |
+| `VolumeKeyMonitor.swift` | F11/F12 hotkey capture via event tap |
+| `AudioDeviceMonitor.swift` | Tracks active audio output device |
+| `SonosController.swift` | Sonos device discovery and control (actor) |
+| `VolumeHUD.swift` | On-screen volume display (Liquid Glass HUD) |
+| `MenuBarContentView.swift` | Menu bar popover UI |
+| `PreferencesWindow.swift` | Settings window |
+
+### Infrastructure Layer
+
+| File | Responsibility |
+|------|---------------|
+| `SSDPSocket.swift` | UDP multicast socket for device discovery |
+| `SSDPDiscoveryService.swift` | SSDP protocol implementation |
+| `SonosNetworkClient.swift` | Type-safe SOAP API client |
+| `XMLParsingHelpers.swift` | XML parsing utilities |
+
+### Important Patterns
+
+1. **Audio Device Trigger**: Only intercept volume keys when specific audio device is active
+2. **Topology Loading**: Must discover devices + load topology before selecting speaker
+3. **Stereo Pairs**: Query visible speaker (it controls both in pair)
+4. **@MainActor**: VolumeHUD and UI components require main actor isolation
+5. **Actor Isolation**: SonosController is an actor - use async/await
+
+### Recent Architecture Work
+
+- **Infrastructure extraction**: Reduced SonosController from 1,732 to 1,471 lines
+- **SOAP migration**: All operations now use SonosNetworkClient
+- **Actor conversion**: Thread-safe async/await patterns throughout
+- **Real-time topology**: UPnP event subscriptions for group changes
+
+---
+
+## Agent Usage Recommendations
+
+### When to Launch Agents
+
+**Before starting complex features:**
+```
+User: "I want to add basic playback controls"
+You: [Launch architecture-advisor to plan component structure]
+```
+
+**After completing significant code:**
+```
+[Complete refactoring of MenuBarContentView]
+You: [Launch architecture-advisor to review changes]
+```
+
+**For UX improvements:**
+```
+User: "The group expansion click target is too small"
+You: [Launch ux-ui-designer for interaction pattern recommendations]
+```
+
+**For feature discovery:**
+```
+User: "I'm thinking about multi-room scene support"
+You: [Launch discovery-documenter to formalize the exploration]
+```
+
+### Agent Coordination
+
+**Run agents in parallel when possible:**
+```swift
+// Single message with multiple Task tool calls
+[Launch architecture-advisor and ux-ui-designer simultaneously]
+```
+
+**Sequential agent workflow:**
+1. `discovery-documenter` - Explore and document problem/solution
+2. `requirements-writer` - Create formal PRD
+3. `ticket-breaker` - Break into implementation tasks
+4. Execute tasks with `architecture-advisor` and `ux-ui-designer` as needed
+
+---
+
+## Common Scenarios
+
+### Scenario 1: Bug Fix
+```
+1. /start bug/descriptive-name
+2. Use TodoWrite to track investigation + fix steps
+3. Test with swift run
+4. /finish (creates PR, updates docs)
+```
+
+### Scenario 2: New Feature
+```
+1. /start feature/descriptive-name
+2. [Optional] Launch discovery-documenter if exploration needed
+3. Launch architecture-advisor for design guidance
+4. Launch ux-ui-designer for UI/UX design
+5. Use TodoWrite to track implementation
+6. Test thoroughly (swift run, ./build-app.sh --install)
+7. /finish
+```
+
+### Scenario 3: Architecture Refactoring
+```
+1. /start refactor/descriptive-name
+2. Launch architecture-advisor for refactoring strategy
+3. Use TodoWrite for step-by-step refactoring plan
+4. Make incremental changes with tests between each
+5. Launch architecture-advisor again to review completed work
+6. /finish
+```
+
+### Scenario 4: Enhancement
+```
+1. /start enhancement/descriptive-name
+2. Launch ux-ui-designer if UI changes involved
+3. Use TodoWrite for implementation steps
+4. Test with swift run
+5. /finish
+```
+
+---
+
+## Sonos API Critical Knowledge
+
+### Group Volume Behavior (from `docs/sonos-api/volume.md`)
+
+- **SetGroupVolume**: Sets absolute volume, maintains speaker ratios
+- **SetRelativeGroupVolume**: Adjusts incrementally, maintains speaker ratios
+- Both commands preserve relative volume differences between speakers
+
+### Coordinator Selection (from `docs/sonos-api/groups.md`)
+
+- First speaker in group becomes coordinator
+- Playing speakers should be prioritized as coordinators
+- Line-in sources are device-specific and cannot be shared
+- Stereo pairs have limitations as coordinators
+
+### Common Pitfalls
+
+1. **Don't assume group volume is sum of individual volumes** - it's proportional
+2. **Always load topology before operations** - device discovery alone isn't enough
+3. **Stereo pairs count as one device** - query the visible speaker
+4. **Line-in audio requires special handling** - can't be shared across groups
+
+---
+
+## Git Workflow Best Practices
+
+### Pre-work Checklist
+- [ ] Check for open PRs (`gh pr list --author @me --state open`)
+- [ ] Ensure on main branch (`git branch --show-current`)
+- [ ] Pull latest changes (`git pull`)
+- [ ] Check ROADMAP.md "In Progress" section for conflicts
+
+### During Work
+- [ ] Create appropriately named branch
+- [ ] Add task to ROADMAP.md "In Progress" section
+- [ ] Commit frequently with descriptive messages
+- [ ] Test before committing
+
+### Post-work Checklist
+- [ ] Update CHANGELOG.md (without PR number)
+- [ ] Remove from ROADMAP.md "In Progress" and planned sections
+- [ ] Commit and push
+- [ ] Create PR with `gh pr create`
+- [ ] Update CHANGELOG.md (add PR number)
+- [ ] Push PR number update
+
+---
+
+## Communication Guidelines
+
+### Be Concise
+- Keep responses under 4 lines for simple tasks
+- Match detail level to task complexity
+- No unnecessary preamble/postamble
+
+### Be Proactive
+- Use TodoWrite for multi-step tasks
+- Launch appropriate agents without asking
+- Run git commands automatically
+- Call out when you're launching an agent and why
+
+### Ask When Unclear
+- Multiple possible approaches
+- User preference needed
+- Architectural decisions with tradeoffs
+
+---
+
+## Tool Usage Tips
+
+### File Operations
+- **Read**: Use for viewing files (supports images, PDFs, notebooks)
+- **Edit**: Use for surgical string replacements
+- **Write**: Only for new files (prefer Edit for existing files)
+- **Glob**: Find files by pattern
+- **Grep**: Search file contents
+
+### Batch Tool Calls
+- Run independent commands in parallel (single message, multiple tool calls)
+- Example: `git status` + `git diff` + `git log` simultaneously
+
+### Bash Tool
+- For terminal operations only (git, npm, swift, etc.)
+- NOT for file operations - use specialized tools
+- Quote paths with spaces: `cd "path with spaces"`
+- Chain dependent commands with `&&`
+
+---
+
+## Anti-Patterns to Avoid
+
+❌ **Don't create files unnecessarily** - prefer editing existing files
+❌ **Don't create documentation proactively** - only when explicitly requested
+❌ **Don't batch todo completions** - mark done immediately
+❌ **Don't skip CHANGELOG.md PR number update** - it's a two-stage process
+❌ **Don't use bash for file reading** - use Read tool
+❌ **Don't commit without testing** - always run swift build or swift run first
+❌ **Don't work on "In Progress" items** - check ROADMAP.md first
+
+---
+
+## Success Metrics
+
+You're doing well when:
+- ✅ PRs are focused on single feature/bug/enhancement
+- ✅ CHANGELOG.md and ROADMAP.md stay in sync
+- ✅ Commits have proper format and co-authorship
+- ✅ TodoWrite shows clear progress tracking
+- ✅ Appropriate agents launched for complex work
+- ✅ Sonos API docs consulted before implementation
+- ✅ Architecture patterns followed (actor isolation, @MainActor, etc.)
+
+---
+
+## Getting Help
+
+- **ROADMAP.md** - Current priorities and known issues
+- **CHANGELOG.md** - Historical context for decisions
+- **CLAUDE.md** - Project-specific collaboration guidelines
+- **CONTRIBUTING.md** - Detailed collaboration guidelines
+- **docs/sonos-api/** - Official Sonos API documentation
+
+When in doubt: Ask the user or launch an appropriate agent for guidance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hierarchical group UI with expandable member controls - groups display as primary cards with drill-down capability to control individual speakers within groups (PR #27)
 - Real-time topology updates via UPnP event subscriptions - automatically detects and reflects speaker grouping changes made from Sonos app or other controllers without manual refresh (PR #36)
 - Audio trigger source dropdown in Preferences window for selecting which audio device activates Sonos control (PR #37)
+- Accessibility permission feedback system: Warning banner in menu bar popover when permission not granted, HUD notification when hotkeys pressed without permission (with "Open Settings" button), real-time permission status monitoring with automatic UI updates
 
 ### Changed
 - Simplified active speaker concept - replaced manual "default speaker" configuration with automatic "last active speaker" tracking, app now remembers what you were last controlling, replaced yellow star button with blue dot indicator, hover-only checkboxes for cleaner UI (PR #40)
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Complete SOAP migration - migrated all 6 remaining SOAP operations (group volume, grouping/ungrouping, playback control) to use SonosNetworkClient, eliminated 229 lines of boilerplate URLSession code, added type-safe AVTransport convenience methods, fixed pre-existing thread safety issues
 
 ### Fixed
+- Group volume slider flicker during adjustment - fixed visual glitching and instability when adjusting group volume by improving slider update synchronization and debouncing (PR #44)
 - Popover height calculation - fixed tiny scroll area on initial display by forcing Auto Layout before measurement, increased max scroll height to accommodate expanded groups with 6+ cards, smooth expand/collapse animations without flicker (PR #41)
 - Real-time group volume slider synchronization - member sliders within expanded groups now update immediately when adjusting group volume, with smooth animations and visual feedback via pulsing connection lines (PR #39)
 - Enhanced group volume controls with bidirectional synchronization - individual speaker sliders now correctly display and control their own volumes (not group volume), group slider updates when individual speakers change, smooth animations throughout (PR #38)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,8 +26,6 @@ _Issues that break core functionality. Must fix immediately._
 
 ### Bugs
 
-- **Hotkeys not working in clean install - no permission feedback**: On clean install, hotkeys produce system "bonk" sound but don't control volume. User gets no indication that accessibility permission is missing or that hotkeys are disabled. Need better permission status visibility and actionable feedback when hotkeys fail. Current permission check only shows alert on first launch, but doesn't help diagnose why hotkeys aren't working after that. Consider: (1) Show permission status in menu bar popover or Preferences, (2) Add HUD notification when hotkeys pressed without required permissions, (3) Add "Test Hotkeys" button in Preferences to verify they're working. (main.swift:193-243, VolumeKeyMonitor.swift)
-
 - **Line-in audio source stops when grouping**: When grouping a speaker playing line-in audio with another speaker, the audio pauses briefly, plays for one second after grouping completes, then cuts out entirely. The Sonos app shows the line-in source is no longer active for the group. This is likely because the non-line-in speaker becomes the group coordinator and line-in sources cannot be shared across groups (device-specific limitation). Need to detect line-in sources and either: (1) make the line-in speaker the coordinator, or (2) warn user before grouping. (SonosController.swift:937-998)
 
 ### UX Critical

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,6 @@ _When starting work on a task, add it here with your branch name and username to
 _Issues that break core functionality. Must fix immediately._
 
 ### Bugs
-- **Group volume slider flickers/glitches when adjusting**: When changing group volume on active speakers, the group slider visually glitches and flickers during adjustment. Member sliders update correctly with proper ratios, but the group slider itself has visual instability. Need to smooth out the slider update animation or debounce the visual feedback. (MenuBarContentView.swift - group volume slider handling)
 
 - **Hotkeys not working in clean install - no permission feedback**: On clean install, hotkeys produce system "bonk" sound but don't control volume. User gets no indication that accessibility permission is missing or that hotkeys are disabled. Need better permission status visibility and actionable feedback when hotkeys fail. Current permission check only shows alert on first launch, but doesn't help diagnose why hotkeys aren't working after that. Consider: (1) Show permission status in menu bar popover or Preferences, (2) Add HUD notification when hotkeys pressed without required permissions, (3) Add "Test Hotkeys" button in Preferences to verify they're working. (main.swift:193-243, VolumeKeyMonitor.swift)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,7 @@ _Issues that break core functionality. Must fix immediately._
 _Major friction points impacting usability, significant missing features, or important architectural issues._
 
 ### Features
+- **Accessibility permission diagnostics (Phase 2)**: Add Preferences window "Hotkeys" section with permission status indicator, "Test Hotkeys" button to verify event tap functionality, and success/failure feedback overlays. Completes the permission feedback system started in Phase 1 by adding proactive verification tools for power users. Implementation: (1) Add new PreferencesWindow section with permission status display (green checkmark if granted, orange warning if denied), (2) Implement "Test Hotkeys" button that creates temporary event tap for 2 seconds to verify F11/F12 detection, (3) Show modal overlay with success ("✅ Hotkeys Working!") or failure ("❌ Hotkeys Not Working") result, (4) Add VolumeKeyMonitor pause/resume methods to prevent conflicts during test, (5) Handle edge cases (permission granted but event tap fails, test timeout, conflicts with other apps). (PreferencesWindow.swift, VolumeKeyMonitor.swift, from UX spec section 3)
 - **Trigger device cache management**: Add ability to refresh trigger sources and cache them persistently. Users should be able to manually delete cached devices that are no longer relevant (similar to WiFi network history - devices remain in cache even when not currently available, but can be manually removed).
 
 - **Merge multiple groups**: Allow merging two or more existing groups into a single larger group. Currently can only create new groups from ungrouped speakers.
@@ -96,6 +97,10 @@ _Nice-to-have improvements that enhance UX or reduce technical debt._
 - **Offline/unreachable speaker detection**: Offline speakers remain in list, controls fail silently. Detect timeouts, show "Offline" badge, auto-refresh topology every 60s. (SonosController.swift) [Added by claudeCode]
 
 ### Architecture
+- **Permission monitoring observer cleanup**: AppSettings tracks permission observers in array but never removes them, potential memory leak if components are deallocated. Add `removePermissionObserver()` method or use weak references. Also consider converting to Combine Publishers for better lifecycle management. (AppSettings.swift:233-240) [Added by claudeCode - Phase 1 technical debt]
+
+- **VolumeKeyMonitor needs pause/resume for testing**: Test Hotkeys feature (Phase 2) requires temporarily disabling main event tap to avoid conflicts. Add `pause()` and `resume()` methods to VolumeKeyMonitor that disable/enable the event tap without full teardown. Store tap state to handle re-entrancy. (VolumeKeyMonitor.swift) [Added by claudeCode - Phase 2 requirement]
+
 - **Excessive debug logging from group volume work**: PR #39 added comprehensive 📊/🎚️ logging for debugging group volume synchronization. Now that it's working, clean up duplicate/verbose logs and wrap remaining debug statements in `#if DEBUG`. Focus on: MenuBarContentView.swift:1063-1215 (volumeChanged, refreshMemberVolumes, performMemberVolumeRefresh), SonosController.swift:1496-1598 (snapshotGroupVolume, setGroupVolume). [Added by claudeCode]
 
 - **Excessive debug logging from popover height work**: PR #41 added comprehensive 🔍 logging for debugging animation timing and layout measurement during expand/collapse. Clean up logs and wrap in `#if DEBUG`. Focus on: MenuBarContentView.swift:1347-1451 (animateInsertMemberCards, animateRemoveMemberCards, card height logging), calculateContentHeight, updatePopoverSize. [Added by claudeCode]

--- a/SonosVolumeController/Sources/main.swift
+++ b/SonosVolumeController/Sources/main.swift
@@ -85,6 +85,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         audioMonitor.start()
         volumeKeyMonitor.start()
 
+        // Start permission monitoring for reactive UI updates
+        settings.startPermissionMonitoring()
+
         // Listen for device discovery completion
         NotificationCenter.default.addObserver(
             self,
@@ -300,6 +303,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Quit current instance
         NSApplication.shared.terminate(nil)
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        // Clean up permission monitoring timer
+        settings.stopPermissionMonitoring()
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #29 - Critical bug where users had no visibility into why hotkeys weren't working on clean installs.

Implements **Phase 1** of the accessibility permission feedback system with three complementary mechanisms:

1. **⚠️ Warning Banner** (Menu Bar Popover)
   - Orange warning banner at top of popover when permission denied
   - "Hotkeys require accessibility permission" message
   - "Enable in System Settings →" link button opens Privacy & Security settings
   - Auto-shows/hides based on real-time permission status

2. **🔒 Permission HUD** (On Hotkey Press)
   - Shows when user presses F11/F12 without accessibility permission
   - Lock icon with "Hotkey Permission Required" title
   - "Open Settings" button for immediate action
   - Debounced (max once per 5 seconds) to prevent spam
   - Manual dismissal (click outside or ESC key)

3. **📊 Real-Time Permission Monitoring** (Background)
   - Thread-safe permission tracking in AppSettings
   - Checks every 2 seconds for permission changes
   - Observer pattern + NotificationCenter for reactive UI updates
   - Automatic cleanup on app termination

## Technical Implementation

### Architecture Pattern
Following architecture-advisor recommendations:
- **Shared State**: Extended AppSettings with observable permission status (Option A)
- **Hybrid Checking**: Periodic monitoring (2s timer) + on-demand validation (Option D)
- **Correct Priority**: Permission checked BEFORE device trigger in VolumeKeyMonitor

### Thread Safety
- Lock-based synchronization (`NSLock`) for permission status property
- Observer array protected by same lock
- Notifications posted on main thread via `Task { @MainActor }`

### Key Files Changed
- `AppSettings.swift`: Permission monitoring infrastructure
- `VolumeKeyMonitor.swift`: Permission check + debounced HUD trigger
- `VolumeHUD.swift`: New `showPermissionRequired()` with action button
- `MenuBarContentView.swift`: Warning banner component + layout integration
- `main.swift`: Lifecycle management (start/stop monitoring)

## User Flows

### New User Clean Install
1. User installs app → First launch shows one-time permission alert
2. User dismisses without granting → Opens popover, sees warning banner
3. User tries F11/F12 → Hears "bonk" + sees permission HUD
4. User clicks "Open Settings" → System Settings opens
5. User grants permission → Banner auto-disappears, hotkeys work immediately

### Existing User (Permission Revoked)
1. User revokes permission in System Settings
2. Within 2 seconds: Warning banner appears in popover
3. User presses hotkey → Permission HUD appears
4. User re-enables permission → Banner disappears, no restart needed

## Phase 2 (Follow-up)
Added to ROADMAP.md P1 Features:
- Preferences window "Hotkeys" section
- Permission status indicator (green checkmark / orange warning)
- "Test Hotkeys" button with success/failure overlays
- VolumeKeyMonitor pause/resume for conflict-free testing

See ROADMAP.md for detailed implementation plan and technical debt items.

## Test Plan
- [x] Build succeeds with no errors
- [ ] Test clean install scenario (permission denied)
- [ ] Test permission grant while app running
- [ ] Test permission revoke while app running
- [ ] Verify HUD debouncing (rapid hotkey presses)
- [ ] Verify banner auto-shows/hides
- [ ] Verify no memory leaks (timer cleanup)

## Screenshots
_(To be added after manual testing)_

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)