### PR TITLE
Feature: Now playing display with song metadata and source badges (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Audio trigger source dropdown in Preferences window for selecting which audio device activates Sonos control (PR #37)
 - Accessibility permission feedback system: Warning banner in menu bar popover when permission not granted, HUD notification when hotkeys pressed without permission (with "Open Settings" button), real-time permission status monitoring with automatic UI updates (PR #45)
 - Hotkey diagnostics in Preferences: Permission status indicator (green checkmark when enabled, orange warning when disabled), "Test Hotkeys" button verifies F11/F12 detection with success/failure overlays, real-time permission status updates, troubleshooting guidance for failed tests (PR #46)
+- Now playing display with song metadata and source badges - shows what's playing on each speaker with color-coded badges (green=streaming, blue=line-in/TV, gray=idle) and real-time song metadata (title • artist) for streaming content, includes pulse animations for active sources and dynamic card height expansion (PR #48)
 
 ### Changed
 - Simplified active speaker concept - replaced manual "default speaker" configuration with automatic "last active speaker" tracking, app now remembers what you were last controlling, replaced yellow star button with blue dot indicator, hover-only checkboxes for cleaner UI (PR #40)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ Discuss with the user which task to tackle next.
 
 ### 2. Starting Work
 
+**Use agents you have access to to ruthlessly parallelize and manage the context window**
+
 1. **Create branch from main**: Use descriptive naming
    - Features: `feature/descriptive-name`
    - Enhancements: `enhancement/descriptive-name`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,8 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
+- **Audio source visibility in UI (Phase 2 of line-in fix)**: Add visual indicators showing what each speaker is playing. Display badges on speaker cards (orange=line-in, purple=TV, green=streaming, gray=idle). Show helper text during grouping to preview which audio will be preserved. Add proactive warnings when selecting incompatible sources. (branch: feature/now-playing-ui, @austinbjohnson)
+
 ---
 
 ## App Store Readiness

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,6 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
-- **Audio source visibility in UI (Phase 2 of line-in fix)**: Add visual indicators showing what each speaker is playing. Display badges on speaker cards (orange=line-in, purple=TV, green=streaming, gray=idle). Show helper text during grouping to preview which audio will be preserved. Add proactive warnings when selecting incompatible sources. (branch: feature/now-playing-ui, @austinbjohnson)
-
 ---
 
 ## App Store Readiness
@@ -37,7 +35,7 @@ _Issues that break core functionality. Must fix immediately._
 _Major friction points impacting usability, significant missing features, or important architectural issues._
 
 ### Features
-- **Audio source visibility in UI (Phase 2 of line-in fix)**: Add visual indicators showing what each speaker is playing. Display badges on speaker cards (orange=line-in, purple=TV, green=streaming, gray=idle). Show helper text during grouping to preview which audio will be preserved. Add proactive warnings when selecting incompatible sources. This completes the UX portion of PR #47's backend work. (LINEIN-5, LINEIN-6 from ticket breakdown)
+- **Album art and UI refinement for now playing display (Phase 2)**: Enhance the now playing feature with album art thumbnails and refined layout. Add 40x40pt album art images positioned left-aligned between the source badge and speaker name. Include 4pt corner radius, 0.5pt border, async loading with NSCache, and fallback SF Symbols (music.note for no artwork, waveform for line-in, tv for TV sources). Reduce card height from 68pt to 64pt with tighter spacing. Reference UX consultation from feature/now-playing-ui for detailed specifications.
 
 - **Trigger device cache management**: Add ability to refresh trigger sources and cache them persistently. Users should be able to manually delete cached devices that are no longer relevant (similar to WiFi network history - devices remain in cache even when not currently available, but can be manually removed).
 


### PR DESCRIPTION
## Summary

Adds visual indicators and real-time metadata display for what's playing on each speaker. This is Phase 1 of the "Now Playing UI" feature - showing source type badges and song metadata (title • artist). Phase 2 will add album art thumbnails and UI refinement.

**Key Features:**
- ✅ Color-coded source badges (green=streaming, blue=line-in/TV, gray=idle) with pulse animations
- ✅ Real-time song metadata extraction (title, artist, album) via UPnP GetPositionInfo
- ✅ DIDL-Lite XML parsing with double-layer HTML entity decoding
- ✅ Dynamic card height expansion (50pt → 68pt) when metadata present
- ✅ Parallel fetching via TaskGroup for all devices
- ✅ Fixed line-in detection to work with paused/stopped states

**Example Display:**
- Streaming: "You Are • quickly, quickly" (green badge)
- Line-in: "Line-In Audio" (blue badge)
- Idle: no text (gray badge)

**Technical Details:**
- Added `NowPlayingInfo` struct and parsing logic to `SonosController`
- Implemented HTML entity decoding using `NSAttributedString` for double-encoded SOAP responses
- Fixed `detectAudioSourceType()` to check URI before transport state
- Modified card identifiers from device name to UUID for reliable lookup
- Added dynamic constraint manipulation to expand cards and reposition elements

## Test plan

- [x] Build succeeds with `swift build -c release`
- [x] Streaming content displays song metadata correctly
- [x] HTML entities decoded properly ("James Blake & Endel" not "&amp;")
- [x] Line-in sources detected even when paused
- [x] Badges appear with correct colors and animations
- [x] Card heights expand properly without layout overlaps
- [x] Active speaker selection works with UUID-based lookup
- [x] All debug logging removed

## Phase 2 (queued in ROADMAP)

- Add 40x40pt album art thumbnails
- Reduce card height from 68pt to 64pt with tighter spacing
- Add fallback SF Symbols for missing artwork

🤖 Generated with [Claude Code](https://claude.com/claude-code)