### PR TITLE
Enhancement: UI Polish Trio - Real-time updates, standby indicator, loading states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Real-time trigger device display updates - trigger device display in menu bar popover now updates immediately when changed in Preferences window, no longer requires closing and reopening popover (PR #TBD)
+- Visual indication for standby mode - menu bar icon dims to 50% opacity when app is disabled (standby mode), providing at-a-glance feedback on whether hotkeys are active (PR #TBD)
+- Loading states for async operations - grouping and ungrouping buttons now show inline progress spinners during 3-5 second operations, preventing confusion and accidental double-clicks (PR #TBD)
 - Custom Sonos speaker icon for menu bar (replaces "S" text)
 - Exit/quit icon updated to "person leaving" (SF Symbol: figure.walk.departure)
 - Settings dropdown now updates when refreshing Sonos devices (PR #13)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,6 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
-- **UI Polish Trio: Real-time trigger device updates, standby mode indicator, loading states** (branch: enhancement/ui-polish-trio, @austinbjohnson)
-
 ---
 
 ## App Store Readiness
@@ -42,12 +40,6 @@ _Major friction points impacting usability, significant missing features, or imp
 - **Merge multiple groups**: Allow merging two or more existing groups into a single larger group. Currently can only create new groups from ungrouped speakers.
 
 ### Enhancements
-- **Real-time trigger device display update**: Trigger device display in menu bar popover only updates when popover is reopened. Add real-time notification/observer pattern so display updates immediately when changed in Preferences without requiring popover close/reopen. (MenuBarContentView.swift:1667, MenuBarPopover.swift:59) [Added by claudeCode]
-
-- **No visual indication when app disabled**: Menu bar icon doesn't change when app is in "Standby" mode (settings.enabled = false). Can't tell at a glance if hotkeys will work. Consider dimming icon or adding slash overlay. (main.swift:32-67) [Added by claudeCode]
-
-- **Loading states during async operations**: No loading indicator when grouping/ungrouping takes 3-5 seconds. Add NSProgressIndicator next to button text and disable button during operation. (MenuBarContentView.swift:1347-1467) [Added by claudeCode]
-
 - **Network error handling improvements**: Network errors show one-time alert, but no way to retry discovery or diagnose issues after dismissal. Add "Refresh" button in Speakers section when no speakers found. (MenuBarContentView.swift:711-719) [Added by claudeCode]
 
 - **Topology cache invalidation**: Topology cache persists for entire app session. If speakers are regrouped via Sonos app or network changes, cache becomes stale. Add automatic invalidation trigger or manual refresh affordance. (SonosController.swift:11-13) [Added by claudeCode]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
-- **Album art and UI refinement for now playing display (Phase 2)** (branch: feature/now-playing-album-art, @austinbjohnson)
+- **UI Polish Trio: Real-time trigger device updates, standby mode indicator, loading states** (branch: enhancement/ui-polish-trio, @austinbjohnson)
 
 ---
 

--- a/SonosVolumeController/Sources/AppSettings.swift
+++ b/SonosVolumeController/Sources/AppSettings.swift
@@ -39,6 +39,12 @@ class AppSettings: @unchecked Sendable {
         set {
             defaults.set(newValue, forKey: Keys.enabled)
             print("Sonos control \(newValue ? "enabled" : "disabled")")
+
+            // Notify observers that enabled state changed
+            NotificationCenter.default.post(
+                name: NSNotification.Name("SonosEnabledStateChanged"),
+                object: newValue
+            )
         }
     }
 
@@ -49,6 +55,12 @@ class AppSettings: @unchecked Sendable {
         set {
             defaults.set(newValue, forKey: Keys.triggerDevice)
             print("Trigger device set to: \(newValue.isEmpty ? "Any Device" : newValue)")
+
+            // Notify observers that trigger device changed
+            NotificationCenter.default.post(
+                name: NSNotification.Name("TriggerDeviceDidChange"),
+                object: newValue
+            )
         }
     }
 

--- a/SonosVolumeController/Sources/main.swift
+++ b/SonosVolumeController/Sources/main.swift
@@ -69,6 +69,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             button.image = iconImage
             button.target = self
             button.action = #selector(togglePopover)
+            button.alphaValue = settings.enabled ? 1.0 : 0.5  // Dim when disabled
             print("🔊 Menu bar icon: Custom Sonos speaker")
         }
         print("📍 Status bar item created")
@@ -87,6 +88,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Start permission monitoring for reactive UI updates
         settings.startPermissionMonitoring()
+
+        // Listen for enabled state changes to update menu bar icon
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateMenuBarIcon),
+            name: NSNotification.Name("SonosEnabledStateChanged"),
+            object: nil
+        )
 
         // Listen for device discovery completion
         NotificationCenter.default.addObserver(
@@ -167,6 +176,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         print("📱 Devices discovered, updating popover...")
         // Just refresh UI - device selection happens in completion handler
         menuBarPopover.refresh()
+    }
+
+    @objc func updateMenuBarIcon() {
+        guard let button = statusItem.button else { return }
+        // Dim icon when app is disabled (standby mode)
+        button.alphaValue = settings.enabled ? 1.0 : 0.5
     }
 
     @objc func handleNetworkError(_ notification: Notification) {


### PR DESCRIPTION
## Summary

Three high-priority UX enhancements that improve app polish and provide better user feedback:

1. **Real-time trigger device display updates** - Popover updates immediately when trigger device changed in Preferences
2. **Visual indication for standby mode** - Menu bar icon dims when app disabled  
3. **Loading states for async operations** - Spinner feedback during grouping/ungrouping

## 1. Real-time Trigger Device Display Updates

**Problem:** Trigger device display in menu bar popover only updated when popover reopened - stale info felt broken.

**Solution:**
- AppSettings posts `TriggerDeviceDidChange` notification when `triggerDeviceName` changes
- MenuBarContentView observes notification and calls `updateTriggerDeviceLabel()`
- Display updates immediately without requiring popover close/reopen

**Technical Details:**
- AppSettings.swift:49-57 - Added notification post in triggerDeviceName setter
- MenuBarContentView.swift:143-149 - Added observer registration
- MenuBarContentView.swift:159-164 - Added notification handler

## 2. Visual Indication for Standby Mode

**Problem:** Menu bar icon unchanged when app disabled - no way to tell at a glance if hotkeys active.

**Solution:**
- Menu bar icon alpha value set to 0.5 when `settings.enabled = false`
- AppSettings posts `SonosEnabledStateChanged` notification when enabled state toggles
- main.swift observes notification and updates icon alpha via `updateMenuBarIcon()`

**Technical Details:**
- AppSettings.swift:39-47 - Added notification post in enabled setter
- main.swift:72 - Set initial alpha based on enabled state
- main.swift:92-98 - Added observer registration
- main.swift:181-185 - Added updateMenuBarIcon() method

## 3. Loading States for Async Operations

**Problem:** Grouping/ungrouping takes 3-5 seconds with no feedback - users confused, caused double-clicks.

**Solution:**
- Added 12x12pt spinning progress indicators to group/ungroup buttons
- Positioned at button leading edge (+12pt)
- Start animation when operation begins, stop on completion/failure/cancellation
- `isDisplayedWhenStopped = false` auto-hides when stopped

**Technical Details:**
- MenuBarContentView.swift:47-48 - Added progress indicator properties
- MenuBarContentView.swift:381-394 - Created progress indicators
- MenuBarContentView.swift:438-446 - Added layout constraints
- MenuBarContentView.swift:1856 - Start spinner on ungroup
- MenuBarContentView.swift:1882 - Stop spinner on ungroup completion
- MenuBarContentView.swift:1945 - Start spinner on group
- MenuBarContentView.swift:2046 - Stop spinner on group success
- MenuBarContentView.swift:2070 - Stop spinner on group failure
- MenuBarContentView.swift:1992, 2022 - Stop spinner on dialog cancellation

## Test Plan

**Feature 1 - Trigger Device Updates:**
- [x] Open Preferences, change trigger device
- [x] Verify menu bar popover updates immediately without closing

**Feature 2 - Standby Mode Indicator:**
- [x] Toggle power button in popover
- [x] Verify menu bar icon dims/brightens in real-time

**Feature 3 - Loading States:**
- [x] Select speakers and click "Group Selected"
- [x] Verify spinner appears on button
- [x] Verify spinner disappears when grouping completes
- [x] Test ungroup operation similarly
- [x] Test canceling dialog - verify spinner stops

## Files Modified

- **AppSettings.swift** (2 notifications): triggerDeviceName setter, enabled setter
- **main.swift** (icon state): observer, updateMenuBarIcon(), initial alpha
- **MenuBarContentView.swift** (all 3 features): trigger device observer, progress indicators with 6 start/stop calls
- **CHANGELOG.md**: Added 3 entries under "Added"
- **ROADMAP.md**: Removed 3 completed P1 items

## Impact

All changes are purely additive - no existing behavior modified. Notifications use existing NotificationCenter pattern. Progress indicators use auto-hide feature to stay clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)