### PR TITLE
Enhancement: Topology cache invalidation and debug logging cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Manual topology refresh button - arrow.clockwise button in menu bar header to force refresh of speaker topology, solves stale cache when speakers regrouped externally via Sonos app or network changes
+- Manual topology refresh button - arrow.clockwise button in menu bar header to force refresh of speaker topology, solves stale cache when speakers regrouped externally via Sonos app or network changes (PR #51)
 - Real-time trigger device display updates - trigger device display in menu bar popover now updates immediately when changed in Preferences window, no longer requires closing and reopening popover (PR #50)
 - Visual indication for standby mode - menu bar icon dims to 50% opacity when app is disabled (standby mode), providing at-a-glance feedback on whether hotkeys are active (PR #50)
 - Loading states for async operations - grouping and ungrouping buttons now show inline progress spinners during 3-5 second operations, preventing confusion and accidental double-clicks (PR #50)
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Line-in audio preservation during grouping - detects line-in sources (turntables, aux inputs) and automatically makes the line-in speaker the group coordinator to prevent audio interruption, includes smart priority system (Line-In > TV > Streaming > Idle) and TOCTOU race condition protection (PR #47)
 
 ### Technical
-- Debug logging cleanup - removed verbose PR #39 (group volume) and PR #41 (popover height) debug logs, wrapped remaining diagnostic logs in #if DEBUG for cleaner release builds, kept important state change notifications
+- Debug logging cleanup - removed verbose PR #39 (group volume) and PR #41 (popover height) debug logs, wrapped remaining diagnostic logs in #if DEBUG for cleaner release builds, kept important state change notifications (PR #51)
 - Infrastructure layer extraction - refactored SonosController god object by extracting infrastructure components (SSDPSocket, SSDPDiscoveryService, SonosNetworkClient, XMLParsingHelpers) into separate, focused modules with clean interfaces and improved testability, reduced SonosController from 1,732 to 1,471 lines (-15%)
 - Complete SOAP migration - migrated all 6 remaining SOAP operations (group volume, grouping/ungrouping, playback control) to use SonosNetworkClient, eliminated 229 lines of boilerplate URLSession code, added type-safe AVTransport convenience methods, fixed pre-existing thread safety issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Manual topology refresh button - arrow.clockwise button in menu bar header to force refresh of speaker topology, solves stale cache when speakers regrouped externally via Sonos app or network changes
 - Real-time trigger device display updates - trigger device display in menu bar popover now updates immediately when changed in Preferences window, no longer requires closing and reopening popover (PR #50)
 - Visual indication for standby mode - menu bar icon dims to 50% opacity when app is disabled (standby mode), providing at-a-glance feedback on whether hotkeys are active (PR #50)
 - Loading states for async operations - grouping and ungrouping buttons now show inline progress spinners during 3-5 second operations, preventing confusion and accidental double-clicks (PR #50)
@@ -44,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Line-in audio preservation during grouping - detects line-in sources (turntables, aux inputs) and automatically makes the line-in speaker the group coordinator to prevent audio interruption, includes smart priority system (Line-In > TV > Streaming > Idle) and TOCTOU race condition protection (PR #47)
 
 ### Technical
+- Debug logging cleanup - removed verbose PR #39 (group volume) and PR #41 (popover height) debug logs, wrapped remaining diagnostic logs in #if DEBUG for cleaner release builds, kept important state change notifications
 - Infrastructure layer extraction - refactored SonosController god object by extracting infrastructure components (SSDPSocket, SSDPDiscoveryService, SonosNetworkClient, XMLParsingHelpers) into separate, focused modules with clean interfaces and improved testability, reduced SonosController from 1,732 to 1,471 lines (-15%)
 - Complete SOAP migration - migrated all 6 remaining SOAP operations (group volume, grouping/ungrouping, playback control) to use SonosNetworkClient, eliminated 229 lines of boilerplate URLSession code, added type-safe AVTransport convenience methods, fixed pre-existing thread safety issues
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,8 @@ For completed work with dates and versions, see [CHANGELOG.md](CHANGELOG.md).
 
 _When starting work on a task, add it here with your branch name and username to help coordinate with other developers._
 
+- **Topology cache invalidation + Debug logging cleanup** (branch: enhancement/topology-cache-and-logging-cleanup, @austinbjohnson)
+
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
@@ -40,11 +42,7 @@ _Major friction points impacting usability, significant missing features, or imp
 - **Merge multiple groups**: Allow merging two or more existing groups into a single larger group. Currently can only create new groups from ungrouped speakers.
 
 ### Enhancements
-- **Network error handling improvements**: Network errors show one-time alert, but no way to retry discovery or diagnose issues after dismissal. Add "Refresh" button in Speakers section when no speakers found. (MenuBarContentView.swift:711-719) [Added by claudeCode]
-
 - **Topology cache invalidation**: Topology cache persists for entire app session. If speakers are regrouped via Sonos app or network changes, cache becomes stale. Add automatic invalidation trigger or manual refresh affordance. (SonosController.swift:11-13) [Added by claudeCode]
-
-- **Group expansion click target too small**: Chevron button is only 20x20pt. Make left third of card expandable or increase chevron hit target to 44x44pt. (MenuBarContentView.swift:1102-1133) [Added by claudeCode]
 
 - **No confirmation for destructive actions**: "Ungroup Selected" immediately dissolves groups without confirmation. Add dialog: "Ungroup X speakers? This cannot be undone." or add undo capability. (MenuBarContentView.swift:1262-1345) [Added by claudeCode]
 
@@ -67,6 +65,8 @@ _Nice-to-have improvements that enhance UX or reduce technical debt._
 - **Basic playback controls**: Add play/pause, next/previous buttons since topology is already loaded. Users wouldn't need to switch to Sonos app for basic transport. [Added by claudeCode]
 
 ### Enhancements
+- **Network error handling improvements**: Network errors show one-time alert, but no way to retry discovery or diagnose issues after dismissal. Add "Refresh" button in Speakers section when no speakers found. (MenuBarContentView.swift:711-719) [Added by claudeCode]
+
 - **Volume normalization when grouping**: Individual speaker volumes preserved when creating groups, which can result in unbalanced audio. Consider normalizing to average or coordinator volume. (SonosController.swift:937-998) [Added by claudeCode]
 
 - **Group expand/collapse state persistence**: Expanded groups reset to collapsed when reopening popover. Persist `expandedGroups` Set to UserDefaults. (MenuBarContentView.swift:50) [Added by claudeCode]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,8 +8,6 @@ For completed work with dates and versions, see [CHANGELOG.md](CHANGELOG.md).
 
 _When starting work on a task, add it here with your branch name and username to help coordinate with other developers._
 
-- **Topology cache invalidation + Debug logging cleanup** (branch: enhancement/topology-cache-and-logging-cleanup, @austinbjohnson)
-
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
@@ -42,8 +40,6 @@ _Major friction points impacting usability, significant missing features, or imp
 - **Merge multiple groups**: Allow merging two or more existing groups into a single larger group. Currently can only create new groups from ungrouped speakers.
 
 ### Enhancements
-- **Topology cache invalidation**: Topology cache persists for entire app session. If speakers are regrouped via Sonos app or network changes, cache becomes stale. Add automatic invalidation trigger or manual refresh affordance. (SonosController.swift:11-13) [Added by claudeCode]
-
 - **No confirmation for destructive actions**: "Ungroup Selected" immediately dissolves groups without confirmation. Add dialog: "Ungroup X speakers? This cannot be undone." or add undo capability. (MenuBarContentView.swift:1262-1345) [Added by claudeCode]
 
 ### Architecture
@@ -93,10 +89,6 @@ _Nice-to-have improvements that enhance UX or reduce technical debt._
 - **Permission monitoring observer cleanup**: AppSettings tracks permission observers in array but never removes them, potential memory leak if components are deallocated. Add `removePermissionObserver()` method or use weak references. Also consider converting to Combine Publishers for better lifecycle management. (AppSettings.swift:233-240) [Added by claudeCode - Phase 1 technical debt]
 
 - **VolumeKeyMonitor needs pause/resume for testing**: Test Hotkeys feature (Phase 2) requires temporarily disabling main event tap to avoid conflicts. Add `pause()` and `resume()` methods to VolumeKeyMonitor that disable/enable the event tap without full teardown. Store tap state to handle re-entrancy. (VolumeKeyMonitor.swift) [Added by claudeCode - Phase 2 requirement]
-
-- **Excessive debug logging from group volume work**: PR #39 added comprehensive 📊/🎚️ logging for debugging group volume synchronization. Now that it's working, clean up duplicate/verbose logs and wrap remaining debug statements in `#if DEBUG`. Focus on: MenuBarContentView.swift:1063-1215 (volumeChanged, refreshMemberVolumes, performMemberVolumeRefresh), SonosController.swift:1496-1598 (snapshotGroupVolume, setGroupVolume). [Added by claudeCode]
-
-- **Excessive debug logging from popover height work**: PR #41 added comprehensive 🔍 logging for debugging animation timing and layout measurement during expand/collapse. Clean up logs and wrap in `#if DEBUG`. Focus on: MenuBarContentView.swift:1347-1451 (animateInsertMemberCards, animateRemoveMemberCards, card height logging), calculateContentHeight, updatePopoverSize. [Added by claudeCode]
 
 - **Remaining Sendable warnings in SonosController**: Multiple warnings for mutation of captured vars and non-Sendable completion handlers. Convert remaining completion handler callbacks to use `@Sendable` closures or pure async/await patterns. (SonosController.swift:461, 465, 476, 790, 926, 1075, 1213, 1266) [Added by claudeCode]
 

--- a/SonosVolumeController/Sources/SonosController.swift
+++ b/SonosVolumeController/Sources/SonosController.swift
@@ -1464,7 +1464,9 @@ actor SonosController {
     /// Must be called on the group coordinator
     func getGroupVolume(group: SonosGroup, completion: @escaping @Sendable (Int?) -> Void) {
         let coordinator = group.coordinator
+        #if DEBUG
         print("🎚️ Getting group volume for: \(group.displayName)")
+        #endif
 
         let request = SonosNetworkClient.SOAPRequest(
             service: .groupRenderingControl,
@@ -1524,15 +1526,6 @@ actor SonosController {
     func setGroupVolume(group: SonosGroup, volume: Int) {
         let coordinator = group.coordinator
         let clampedVolume = max(0, min(100, volume))
-        print("🎚️ ========================================")
-        print("🎚️ Setting group volume for \(group.displayName) to \(clampedVolume)")
-        print("🎚️ Group has \(group.members.count) members:")
-        for member in group.members {
-            print("🎚️   - \(member.name)")
-        }
-        print("🎚️ Step 1: Taking snapshot to capture current speaker ratios")
-        print("🎚️ Step 2: SetGroupVolume will use snapshot to maintain ratios")
-        print("🎚️ ========================================")
 
         // First, snapshot the current volume ratios
         snapshotGroupVolume(group: group) { [weak self] success in


### PR DESCRIPTION
## Summary
- Added manual topology refresh button for cache invalidation
- Cleaned up verbose debug logs from PRs #39 and #41
- Wrapped remaining diagnostic logs in `#if DEBUG`

## Changes

### Topology Cache Invalidation
- **Manual refresh button**: Arrow.clockwise icon in menu bar header
- **Functionality**: Calls `discoverDevices(forceRefreshTopology: true)` to invalidate stale cache
- **Use case**: When speakers regrouped externally via Sonos app and topology becomes stale
- **UX**: Shows loading state during refresh, positioned next to power button with tooltip

### Debug Logging Cleanup

**PR #39 (Group Volume) - Removed:**
- Volume slider change logs (fired on every movement)
- SetVolume call logs with redundant comments
- Member volume refresh notifications
- Individual member query logs (per speaker)
- Large banner block in setGroupVolume (9 lines)

**PR #39 - Wrapped in #if DEBUG:**
- Member volume refresh summary
- Member slider update logs (most valuable for debugging)
- getGroupVolume call logs

**PR #41 (Popover Height) - Removed:**
- Individual card height logging (per card)
- Spacing calculation logs

**PR #41 - Wrapped in #if DEBUG:**
- calculateContentHeight entry/exit logs
- updatePopoverSize parameter and dimension logs

**Kept (Important):**
- All topology change notifications (📊)
- Volume control type identification (🎚️)
- Operational state change logs

## Test Plan
- [x] Build succeeds: `swift build -c release`
- [x] Release build has clean console output
- [x] Debug builds retain diagnostic logging
- [ ] Manual refresh button clears topology cache and reloads
- [ ] Button shows loading state during refresh
- [ ] UI updates after successful refresh

## Impact
- **Performance**: Reduced console I/O in production builds
- **Stability**: Users can manually invalidate stale topology cache
- **Developer Experience**: Debug builds retain all diagnostic logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)