### PR TITLE
Enhancement: Eliminate now-playing flicker on card selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Album art thumbnails in now playing display - 40x40pt album artwork with 4pt corner radius and subtle border, async loading with NSCache for performance, fallback SF Symbols for sources without artwork (music.note for streaming, waveform for line-in, tv for TV), refined 64pt card layout with tighter spacing (PR #49)
 
 ### Changed
-- Eliminated now-playing content flicker when clicking speaker cards by implementing cache-based rendering. Cards now display cached now-playing data immediately during rebuilds, preventing the UI twitch.
+- Eliminated now-playing content flicker when clicking speaker cards by implementing cache-based rendering. Cards now display cached now-playing data immediately during rebuilds, preventing the UI twitch. (PR #52)
 - Simplified active speaker concept - replaced manual "default speaker" configuration with automatic "last active speaker" tracking, app now remembers what you were last controlling, replaced yellow star button with blue dot indicator, hover-only checkboxes for cleaner UI (PR #40)
 - Fixed checkbox vs. card click confusion by adding explicit star buttons to set default speaker/group - eliminates accidental clicks between selecting for grouping vs setting as default (PR #34)
 - Simplified UI by streamlining trigger display and preferences window - replaced radio button list with read-only display, removed redundant Audio Devices and Sonos tabs from preferences (PR #32)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Album art thumbnails in now playing display - 40x40pt album artwork with 4pt corner radius and subtle border, async loading with NSCache for performance, fallback SF Symbols for sources without artwork (music.note for streaming, waveform for line-in, tv for TV), refined 64pt card layout with tighter spacing (PR #49)
 
 ### Changed
+- Eliminated now-playing content flicker when clicking speaker cards by implementing cache-based rendering. Cards now display cached now-playing data immediately during rebuilds, preventing the UI twitch.
 - Simplified active speaker concept - replaced manual "default speaker" configuration with automatic "last active speaker" tracking, app now remembers what you were last controlling, replaced yellow star button with blue dot indicator, hover-only checkboxes for cleaner UI (PR #40)
 - Fixed checkbox vs. card click confusion by adding explicit star buttons to set default speaker/group - eliminates accidental clicks between selecting for grouping vs setting as default (PR #34)
 - Simplified UI by streamlining trigger display and preferences window - replaced radio button list with read-only display, removed redundant Audio Devices and Sonos tabs from preferences (PR #32)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,148 @@
 
 This document guides collaboration between Claude and the developer on the Sonos Volume Controller project.
 
+## 🚀 CRITICAL: Agent-First Development Strategy
+
+**ALWAYS USE AGENTS TO PRESERVE CONTEXT AND PARALLELIZE WORK**
+
+This project requires aggressive agent usage to:
+- **Preserve context window** - Agents have their own context, preventing main conversation bloat
+- **Parallelize work** - Run multiple agents simultaneously for maximum efficiency
+- **Deep dive without distraction** - Let agents handle detailed analysis while you orchestrate
+
+### When to Use Agents (Almost Always!)
+
+**Use agents by default for ANY task that involves:**
+- Reading multiple files (use `codebase-analyzer`, `codebase-locator`, or `codebase-pattern-finder`)
+- Searching for patterns or implementations (use `codebase-pattern-finder`)
+- Understanding architecture or dependencies (use `codebase-analyzer`)
+- Researching documentation (use `thoughts-locator` for docs/ or thoughts/)
+- Any task requiring more than 2-3 file reads
+
+### Agent Usage Patterns
+
+#### Pattern 1: Parallel Analysis (Most Common)
+When starting ANY new task, immediately launch agents in parallel:
+
+```
+Task: "Implement real-time transport state updates"
+
+CORRECT ✅:
+- Launch codebase-analyzer (find current metadata system) IN PARALLEL WITH
+- Launch codebase-pattern-finder (find UPnP patterns) IN PARALLEL WITH
+- Launch thoughts-locator (find relevant Sonos API docs)
+→ All 3 agents run simultaneously, results come back together
+
+WRONG ❌:
+- Read MenuBarContentView.swift
+- Read SonosController.swift
+- Read UPnPEventListener.swift
+- Read docs/sonos-api/upnp-local-api.md
+→ Uses 4x the context, takes 4x longer
+```
+
+#### Pattern 2: Deep Dive Without Context Burn
+When you need detailed understanding:
+
+```
+CORRECT ✅:
+"I need to understand how volume control works"
+→ Launch codebase-analyzer with specific prompt
+→ Agent reads all relevant files, returns summary
+→ You get the answer without burning 2000 tokens per file
+
+WRONG ❌:
+→ Read VolumeKeyMonitor.swift (800 lines)
+→ Read SonosController.swift (1400 lines)
+→ Read MenuBarContentView.swift (1600 lines)
+→ Context window now at 60%
+```
+
+#### Pattern 3: Search Before Read
+NEVER use Grep/Read for open-ended searches:
+
+```
+CORRECT ✅:
+"Find where speakers are selected"
+→ Launch codebase-locator agent
+→ Agent searches, finds exact locations, returns targeted results
+
+WRONG ❌:
+→ Grep for "selectSpeaker"
+→ Read MenuBarContentView.swift around that
+→ Grep for related patterns
+→ Read more files
+→ Repeat 5x
+```
+
+### Available Agents & When to Use Them
+
+#### Research & Analysis Agents
+| Agent | Use When | Example |
+|-------|----------|---------|
+| **codebase-locator** | Finding files/components by feature description | "Find where volume hotkeys are handled" |
+| **codebase-analyzer** | Understanding implementation details | "How does the SSDP discovery work?" |
+| **codebase-pattern-finder** | Finding similar code or usage examples | "Show me how other SOAP commands are structured" |
+| **thoughts-locator** | Finding documentation in docs/ or thoughts/ | "Find Sonos API documentation about events" |
+| **thoughts-analyzer** | Deep research into documentation | "Understand the full UPnP event subscription flow" |
+
+#### Operational Agents (CRITICAL - Use These Too!)
+| Agent | Use When | Example |
+|-------|----------|---------|
+| **git-workflow-manager** | ANY Git/GitHub operations | "Create branch, commit changes, create PR" |
+| **general-purpose** | Building, running, testing the app | "Build the app and check for errors, then run it and monitor logs for transport subscriptions" |
+
+**⚠️ IMPORTANT: Don't manually run/test - use general-purpose agent!**
+- Running `swift run` or `swift build` manually wastes context
+- Use general-purpose agent to run, monitor logs, and report back
+- Agent can filter logs, watch for specific patterns, and give you a summary
+
+### Parallel Agent Execution
+
+**ALWAYS run agents in parallel when tasks are independent:**
+
+```swift
+// Single message with multiple Task tool calls:
+Task(codebase-analyzer: "Analyze blue dot implementation")
+Task(codebase-locator: "Find now-playing metadata code")
+Task(thoughts-locator: "Find Sonos transport state docs")
+// All execute simultaneously!
+```
+
+### Default Agent Strategy
+
+**For every new task:**
+1. Immediately identify what you need to know
+2. Launch 2-3 agents in parallel to gather information
+3. Wait for results, then plan implementation
+4. Only read specific files when you need to edit them
+5. **After coding: Use general-purpose agent to test/run**
+
+### Testing & Running Workflow
+
+**WRONG ❌:**
+```
+You: "Let me build and test..."
+→ Bash: swift build
+→ Bash: swift run &
+→ Wait/check logs manually
+→ Context window filling up with build output
+```
+
+**CORRECT ✅:**
+```
+You: "Let me test this with an agent"
+→ Task(general-purpose): "Build the app with swift build, check for errors.
+   Then run it with swift run, monitor logs for 10 seconds, and look for:
+   - Transport subscription messages (🎵)
+   - Any errors or warnings
+   Report back what you find."
+→ Agent handles everything, returns concise summary
+→ Zero context burn
+```
+
+**Remember:** Using agents is faster, cleaner, and preserves context for ALL work - research AND operations!
+
 ## Workflow
 
 ### 1. Picking Next Task
@@ -18,7 +160,13 @@ Discuss with the user which task to tackle next.
 
 ### 2. Starting Work
 
-**Use agents you have access to to ruthlessly parallelize and manage the context window**
+**⚡ STEP 0: Launch Agents First!**
+
+Before doing ANYTHING else, launch agents to gather context:
+- Use `codebase-locator` to find relevant files
+- Use `codebase-analyzer` to understand existing implementation
+- Use `thoughts-locator` if Sonos API docs might be relevant
+- **Run them in parallel** (single message with multiple Task calls)
 
 1. **Create branch from main**: Use descriptive naming
    - Features: `feature/descriptive-name`
@@ -37,7 +185,9 @@ Discuss with the user which task to tackle next.
 
 ### 3. Completing Work
 
-1. **Test**: Build with `swift build -c release` or `swift run`
+1. **Test**: Use general-purpose agent to build and test
+   - **Don't manually run swift build/swift run** - use agent to preserve context
+   - Agent can build, run, monitor logs, and report issues
 
 2. **Update documentation** (first time - without PR number):
    - Add to `CHANGELOG.md` under appropriate section (Added/Changed/Fixed)
@@ -71,7 +221,7 @@ Discuss with the user which task to tackle next.
 
 This ensures the PR number is accurate in the branch before merging.
 
-### 4. After Merge
+### 4. After Merge (use git)
 
 User merges PR on GitHub, then locally:
 ```bash
@@ -158,10 +308,26 @@ Key documentation files:
 
 ## Tips for Development
 
+- **🚀 USE AGENTS FIRST** - Before reading any files, launch agents in parallel to gather context
 - Always check `ROADMAP.md` at start of session
 - Check "In Progress" section before starting work to avoid conflicts
-- **Consult `docs/sonos-api/` before implementing Sonos features**
+- **Consult `docs/sonos-api/` before implementing Sonos features** (use `thoughts-locator` agent!)
 - Use `swift run` for quick iteration during development
 - Only use `./build-app.sh --install` when ready to test installed behavior
 - Keep PRs focused on single feature/enhancement/bug
 - See `CONTRIBUTING.md` for detailed collaboration guidelines
+
+### Agent Usage Checklist
+
+**Before starting ANY task:**
+- [ ] Can I use `codebase-locator` to find relevant files? (YES = use it)
+- [ ] Do I need to understand existing code? (YES = use `codebase-analyzer`)
+- [ ] Are there similar patterns I can follow? (YES = use `codebase-pattern-finder`)
+- [ ] Is there API documentation I should read? (YES = use `thoughts-locator`)
+- [ ] Can I run multiple agents in parallel? (Almost always YES)
+
+**After making changes:**
+- [ ] Do I need to test/build/run? (YES = use `general-purpose` agent)
+- [ ] Do I need Git operations? (YES = use `git-workflow-manager` agent)
+
+**Default answer:** Use agents for EVERYTHING - research, testing, and Git operations!

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,8 @@ _Issues that break core functionality. Must fix immediately._
 
 ### Bugs
 
+- **Transport state updates not working for certain speakers**: Bathroom and Bedroom don't receive real-time transport state updates when playback changes, but Kitchen Move works correctly. NOTE: Bedroom is a stereo pair but Bathroom is NOT, so this is not stereo-pair specific. All speakers subscribe successfully and receive initial events, but play/pause changes don't trigger UI updates for these two speakers. Attempted fix with satellite-to-visible UUID mapping didn't resolve. Need to investigate if there's a UUID mismatch between subscription, NOTIFY callback, and card identifier, or if these specific speakers send events differently. (SonosController.swift:363-397, 783-825, MenuBarContentView.swift:177-231) [Added 2025-10-04]
+
 ### UX Critical
 
 ### Architecture Critical

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,8 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
+- **Real-time playing state updates and remove audio source indicator**: Listen for UPnP AVTransport events to update content display in real-time even when paused, and remove the blue dot indicator showing audio source state for cleaner UI (branch: enhancement/realtime-state-updates-and-ui-polish, @austinbjohnson)
+
 ---
 
 ## App Store Readiness


### PR DESCRIPTION
## Summary
- Fixed UI flicker where now-playing content (album art, track titles) would disappear and reappear when clicking speaker cards
- Implemented cache-based rendering system for instant, smooth card selection

## Changes
- Added `nowPlayingCache` dictionary to preserve now-playing data across rebuilds
- Modified `createSpeakerCard()` and `createGroupCard()` to use cached data immediately
- Updated `updateCardWithNowPlaying()` to populate cache
- Removed unnecessary `populateSpeakers()` calls from `selectSpeaker()` and `selectGroup()` handlers

## Test Plan
- [x] Build succeeds without errors
- [x] Click speaker cards - no flicker, instant selection
- [x] Click group cards - no flicker, instant selection
- [x] Now-playing content persists during selection
- [x] Fresh data still fetched on discovery/grouping operations

## Technical Details
The flicker occurred because clicking a card triggered `populateSpeakers()` which destroyed and rebuilt all cards, then asynchronously re-fetched now-playing data. This created a visible gap (50-200ms) where cards appeared without content.

The fix caches now-playing data and displays it immediately during card creation, eliminating the async delay and providing instant visual feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)