### PR TITLE
Fix: Transport state updates - HTML entity decoding in AVTransport events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed hotkeys not working in installed app - reverted to F11/F12 defaults, fixed CGEventFlags conversion, added network entitlements, improved permission flow with auto-restart (PR #22)
 
 ### Fixed
-- Transport state updates for all speakers - fixed critical bug where play/pause events weren't triggering UI updates. Root cause: Sonos sends AVTransport events with HTML-encoded XML (`&lt;TransportState&gt;`) rather than raw tags. Added HTML entity decoding before parsing. Also fixed concurrency crash by ensuring NotificationCenter posts happen on main thread via MainActor. All speakers now receive real-time play/pause UI updates (PR #XX)
-- Now playing metadata overlapping text - fixed UI bug where track metadata would overlap instead of replacing when tracks changed. Methods now update existing UI elements instead of creating new ones on top of old ones (PR #XX)
+- Transport state updates for all speakers - fixed critical bug where play/pause events weren't triggering UI updates. Root cause: Sonos sends AVTransport events with HTML-encoded XML (`&lt;TransportState&gt;`) rather than raw tags. Added HTML entity decoding before parsing. Also fixed concurrency crash by ensuring NotificationCenter posts happen on main thread via MainActor. All speakers now receive real-time play/pause UI updates (PR #53)
+- Now playing metadata overlapping text - fixed UI bug where track metadata would overlap instead of replacing when tracks changed. Methods now update existing UI elements instead of creating new ones on top of old ones (PR #53)
 - Line-in audio preservation during grouping - detects line-in sources (turntables, aux inputs) and automatically makes the line-in speaker the group coordinator to prevent audio interruption, includes smart priority system (Line-In > TV > Streaming > Idle) and TOCTOU race condition protection (PR #47)
 
 ### Technical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed hotkeys not working in installed app - reverted to F11/F12 defaults, fixed CGEventFlags conversion, added network entitlements, improved permission flow with auto-restart (PR #22)
 
 ### Fixed
+- Transport state updates for all speakers - fixed critical bug where play/pause events weren't triggering UI updates. Root cause: Sonos sends AVTransport events with HTML-encoded XML (`&lt;TransportState&gt;`) rather than raw tags. Added HTML entity decoding before parsing. Also fixed concurrency crash by ensuring NotificationCenter posts happen on main thread via MainActor. All speakers now receive real-time play/pause UI updates (PR #XX)
+- Now playing metadata overlapping text - fixed UI bug where track metadata would overlap instead of replacing when tracks changed. Methods now update existing UI elements instead of creating new ones on top of old ones (PR #XX)
 - Line-in audio preservation during grouping - detects line-in sources (turntables, aux inputs) and automatically makes the line-in speaker the group coordinator to prevent audio interruption, includes smart priority system (Line-In > TV > Streaming > Idle) and TOCTOU race condition protection (PR #47)
 
 ### Technical

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
-- **Real-time playing state updates and remove audio source indicator**: Listen for UPnP AVTransport events to update content display in real-time even when paused, and remove the blue dot indicator showing audio source state for cleaner UI (branch: enhancement/realtime-state-updates-and-ui-polish, @austinbjohnson)
+- **Fix transport state updates for grouped speakers**: Investigate and fix P0 bug where Bathroom and Bedroom speakers don't receive real-time transport state updates. Using evidence-based approach: research UPnP/GENA best practices, add diagnostic logging, analyze root cause, then implement fix. (branch: fix/transport-state-uuid-mismatch, @austinbjohnson)
 
 ---
 
@@ -28,7 +28,7 @@ _Issues that break core functionality. Must fix immediately._
 
 ### Bugs
 
-- **Transport state updates not working for certain speakers**: Bathroom and Bedroom don't receive real-time transport state updates when playback changes, but Kitchen Move works correctly. NOTE: Bedroom is a stereo pair but Bathroom is NOT, so this is not stereo-pair specific. All speakers subscribe successfully and receive initial events, but play/pause changes don't trigger UI updates for these two speakers. Attempted fix with satellite-to-visible UUID mapping didn't resolve. Need to investigate if there's a UUID mismatch between subscription, NOTIFY callback, and card identifier, or if these specific speakers send events differently. (SonosController.swift:363-397, 783-825, MenuBarContentView.swift:177-231) [Added 2025-10-04]
+- **Non-Apple Music sources not updating UI**: Transport state updates work for Apple Music and most streaming services, but certain sources (e.g., Beats 1 radio, possibly other radio stations) don't trigger UI metadata updates. Core play/pause state changes work, but track/station information doesn't refresh. May be related to different metadata formats or missing fields in non-music-streaming content. (MenuBarContentView.swift, SonosController.swift) [Added 2025-10-04]
 
 ### UX Critical
 
@@ -150,3 +150,7 @@ _(Moved to P0/P1 sections)_
 ## Known Limitations
 
 - **Line-in audio lost when grouping with stereo pairs**: When a stereo pair is playing line-in audio and grouped with another speaker, the line-in audio stops because the non-stereo-pair becomes coordinator and line-in sources are device-specific (cannot be shared). Workaround: Manually set the stereo pair with line-in as the coordinator in the Sonos app, or use streaming sources instead of line-in when grouping.
+
+## Recently Resolved
+
+- **Transport state updates not working for certain speakers** ✅ FIXED (2025-10-04): Root cause was HTML-encoded XML in AVTransport LastChange events. Sonos sends transport state wrapped in `&lt;TransportState&gt;` entities rather than raw XML tags. Added HTML entity decoding (`&quot;`, `&lt;`, `&gt;`, `&amp;`) before XML parsing. Also fixed concurrency crash by wrapping NotificationCenter.post in MainActor.run. All speakers now receive real-time play/pause UI updates. (PR #XX)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,6 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
-- **Fix transport state updates for grouped speakers**: Investigate and fix P0 bug where Bathroom and Bedroom speakers don't receive real-time transport state updates. Using evidence-based approach: research UPnP/GENA best practices, add diagnostic logging, analyze root cause, then implement fix. (branch: fix/transport-state-uuid-mismatch, @austinbjohnson)
-
 ---
 
 ## App Store Readiness

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,4 +153,4 @@ _(Moved to P0/P1 sections)_
 
 ## Recently Resolved
 
-- **Transport state updates not working for certain speakers** ✅ FIXED (2025-10-04): Root cause was HTML-encoded XML in AVTransport LastChange events. Sonos sends transport state wrapped in `&lt;TransportState&gt;` entities rather than raw XML tags. Added HTML entity decoding (`&quot;`, `&lt;`, `&gt;`, `&amp;`) before XML parsing. Also fixed concurrency crash by wrapping NotificationCenter.post in MainActor.run. All speakers now receive real-time play/pause UI updates. (PR #XX)
+- **Transport state updates not working for certain speakers** ✅ FIXED (2025-10-04): Root cause was HTML-encoded XML in AVTransport LastChange events. Sonos sends transport state wrapped in `&lt;TransportState&gt;` entities rather than raw XML tags. Added HTML entity decoding (`&quot;`, `&lt;`, `&gt;`, `&amp;`) before XML parsing. Also fixed concurrency crash by wrapping NotificationCenter.post in MainActor.run. All speakers now receive real-time play/pause UI updates. (PR #53)

--- a/SonosVolumeController/Sources/SonosController.swift
+++ b/SonosVolumeController/Sources/SonosController.swift
@@ -802,17 +802,19 @@ actor SonosController {
                     devices[index].nowPlaying = nowPlaying
                 }
 
-                // Notify UI of the change
-                NotificationCenter.default.post(
-                    name: NSNotification.Name("SonosTransportStateDidChange"),
-                    object: nil,
-                    userInfo: [
-                        "deviceUUID": deviceUUID,
-                        "state": state,
-                        "trackURI": trackURI as Any,
-                        "metadata": metadata as Any
-                    ]
-                )
+                // Notify UI of the change (must happen on main thread)
+                await MainActor.run {
+                    NotificationCenter.default.post(
+                        name: NSNotification.Name("SonosTransportStateDidChange"),
+                        object: nil,
+                        userInfo: [
+                            "deviceUUID": deviceUUID,
+                            "state": state,
+                            "trackURI": trackURI as Any,
+                            "metadata": metadata as Any
+                        ]
+                    )
+                }
             }
 
         case .subscriptionExpired(let sid):

--- a/SonosVolumeController/docs/sonos-api/upnp-events.md
+++ b/SonosVolumeController/docs/sonos-api/upnp-events.md
@@ -1,0 +1,324 @@
+# UPnP Event Subscriptions for Sonos Control
+
+## Overview
+
+UPnP (Universal Plug and Play) uses GENA (General Event Notification Architecture) to enable devices to notify control points of state changes. This is essential for real-time UI updates when Sonos speakers change playback state, group configuration, or volume.
+
+**Key Concept**: Instead of polling devices repeatedly, we subscribe once and receive push notifications (NOTIFY callbacks) whenever state changes.
+
+## GENA Protocol Basics
+
+### SUBSCRIBE Request
+
+To receive events, send an HTTP SUBSCRIBE request to the service's event endpoint.
+
+**Request Format:**
+```http
+SUBSCRIBE /MediaRenderer/AVTransport/Event HTTP/1.1
+HOST: 192.168.1.100:1400
+CALLBACK: <http://192.168.1.50:3400/notify>
+NT: upnp:event
+TIMEOUT: Second-1800
+```
+
+**Headers:**
+- `CALLBACK`: URL where device will send NOTIFY callbacks (your listener)
+- `NT`: Notification Type, always `upnp:event` for subscriptions
+- `TIMEOUT`: Subscription duration (e.g., `Second-1800` = 30 minutes)
+
+**Response:**
+```http
+HTTP/1.1 200 OK
+SID: uuid:RINCON_ABC123-1234
+TIMEOUT: Second-1800
+```
+
+**Response Headers:**
+- `SID`: Subscription ID (used to match NOTIFY callbacks and renew subscriptions)
+- `TIMEOUT`: Actual timeout granted by device
+
+### NOTIFY Callback
+
+When state changes, the device sends an HTTP NOTIFY request to your callback URL.
+
+**Callback Format:**
+```http
+NOTIFY /notify HTTP/1.1
+HOST: 192.168.1.50:3400
+SID: uuid:RINCON_ABC123-1234
+SEQ: 0
+NT: upnp:event
+NTS: upnp:propchange
+Content-Type: text/xml
+
+<?xml version="1.0"?>
+<e:propertyset xmlns:e="urn:schemas-upnp-org:event-1-0">
+  <e:property>
+    <LastChange>&lt;Event...&gt;</LastChange>
+  </e:property>
+</e:propertyset>
+```
+
+**Headers:**
+- `SID`: Subscription ID (match to your subscription)
+- `SEQ`: Sequence number (increments with each notification)
+- `NTS`: Notification Sub Type, `upnp:propchange` for state changes
+
+### Subscription Renewal
+
+Subscriptions expire after the timeout period. Renew before expiration to maintain continuous updates.
+
+**Renewal Request:**
+```http
+SUBSCRIBE /MediaRenderer/AVTransport/Event HTTP/1.1
+HOST: 192.168.1.100:1400
+SID: uuid:RINCON_ABC123-1234
+TIMEOUT: Second-1800
+```
+
+**Best Practice**: Renew at **80% of timeout** to handle network delays (e.g., renew at 24 minutes for 30-minute timeout).
+
+### Unsubscribe
+
+To stop receiving events:
+
+```http
+UNSUBSCRIBE /MediaRenderer/AVTransport/Event HTTP/1.1
+HOST: 192.168.1.100:1400
+SID: uuid:RINCON_ABC123-1234
+```
+
+## Sonos Event Services
+
+Sonos speakers expose three key services with eventing support:
+
+### 1. ZoneGroupTopology Service
+
+**Endpoint**: `/ZoneGroupTopology/Event`
+
+**Purpose**: Notifies of group changes, coordinator handoffs, speaker additions/removals.
+
+**Key Event Variable**: `ZoneGroupState` (HTML-encoded XML containing full topology)
+
+**Use Cases**:
+- Detect when speakers join/leave groups
+- Update UI when groups are created/dissolved via Sonos app
+- Handle coordinator role changes
+
+**Implementation**: `UPnPEventListener.swift` - subscribed for all coordinators
+
+### 2. AVTransport Service
+
+**Endpoint**: `/MediaRenderer/AVTransport/Event`
+
+**Purpose**: Notifies of playback state changes (play/pause/stop), track changes, metadata updates.
+
+**Key Event Variable**: `LastChange` (XML containing transport state, track URI, metadata)
+
+**Example LastChange XML:**
+```xml
+<Event xmlns="urn:schemas-upnp-org:metadata-1-0/AVT/">
+  <InstanceID val="0">
+    <TransportState val="PLAYING"/>
+    <CurrentTrackURI val="x-sonos-spotify:..."/>
+    <CurrentTrackMetaData val="&lt;DIDL-Lite...&gt;"/>
+  </InstanceID>
+</Event>
+```
+
+**Use Cases**:
+- Update play/pause button states in UI
+- Display "Now Playing" information
+- Show track progress
+
+**Implementation**: `UPnPEventListener.swift` + `SonosController.swift:783-832`
+
+### 3. RenderingControl Service
+
+**Endpoint**: `/MediaRenderer/RenderingControl/Event`
+
+**Purpose**: Notifies of volume changes, mute state changes.
+
+**Key Event Variables**: `Volume`, `Mute`
+
+**Use Cases**:
+- Sync volume slider when changed in Sonos app
+- Update mute icon
+
+**Status**: Not yet implemented in SonosVolumeController
+
+## Subscription Strategies
+
+### Strategy 1: All-Devices Subscription ⭐ (Current Implementation)
+
+**Approach**: Subscribe to AVTransport events for **every discovered device**.
+
+**Pros:**
+- ✅ Simple and stable - no dynamic resubscription logic
+- ✅ Handles group changes automatically (topology updates the UUID mapping)
+- ✅ Captures events regardless of which device emits them
+- ✅ No risk of missing events during coordinator handoffs
+
+**Cons:**
+- ❌ More network overhead (more subscriptions = more NOTIFY callbacks)
+- ❌ Requires UUID mapping to route events to correct UI components
+
+**Best For**: Applications where simplicity and reliability outweigh bandwidth concerns.
+
+**When to Use**: 
+- Dynamic group environments (frequent grouping/ungrouping)
+- When you need guaranteed event delivery
+- When network bandwidth is not constrained
+
+### Strategy 2: Coordinator-Only Subscription
+
+**Approach**: Subscribe only to group coordinators and ungrouped speakers.
+
+**Pros:**
+- ✅ Reduced network overhead (~50% fewer subscriptions in typical households)
+- ✅ Events naturally match UI card identifiers (coordinators)
+- ✅ No complex UUID mapping needed
+
+**Cons:**
+- ❌ Complex subscription management (subscribe/unsubscribe on group changes)
+- ❌ Risk of missing events during coordinator handoffs
+- ❌ Must handle topology changes reactively
+
+**Best For**: Applications with stable group configurations and bandwidth constraints.
+
+**When to Use**:
+- Groups rarely change
+- Network bandwidth is limited
+- You have robust topology change handling
+
+### Trade-Off Analysis
+
+| Factor | All-Devices | Coordinator-Only |
+|--------|-------------|------------------|
+| Complexity | Low | High |
+| Reliability | High | Medium |
+| Network Overhead | Higher | Lower |
+| Maintainability | Easy | Difficult |
+| Bug Risk | Low | Medium-High |
+
+**Recommendation**: Start with **All-Devices** subscription for reliability, then optimize to Coordinator-Only if performance becomes an issue.
+
+## Implementation in SonosVolumeController
+
+### Current Architecture
+
+**UPnPEventListener.swift**: HTTP server (SwiftNIO) that receives NOTIFY callbacks
+- Listens on dynamic port (system-assigned)
+- Routes callbacks to appropriate event streams
+- Handles subscription lifecycle (renewal, expiration)
+
+**SonosController.swift**: Manages subscriptions and processes events
+- Subscribes to all devices on discovery (`subscribeToAllDevicesForTransport()`)
+- Maps UUIDs to route events to correct UI components
+- Updates device cache with new state
+
+**MenuBarContentView.swift**: UI updates based on notifications
+- Listens for `SonosTransportStateDidChange` NotificationCenter events
+- Finds card by UUID and refreshes now-playing info
+
+### Event Flow
+
+```
+1. Sonos Speaker → NOTIFY callback → UPnPEventListener HTTP server
+2. UPnPEventListener → Parse XML → Emit TransportEvent
+3. SonosController → Handle event → Update device cache → Post notification
+4. MenuBarContentView → Receive notification → Find card → Update UI
+```
+
+### UUID Mapping Strategy
+
+**Problem**: Card identifiers may not match event UUIDs in certain scenarios:
+
+1. **Stereo Pairs**: Satellite speaker is invisible, events come from satellite UUID but card uses visible speaker UUID
+2. **Groups**: Member devices may emit events but cards use coordinator UUID
+
+**Solution**: `satelliteToVisibleMap` dictionary maps event UUIDs to card UUIDs.
+
+**Current Mapping** (SonosController.swift:363-373):
+```swift
+// Maps stereo pair satellites to visible speakers
+satelliteToVisibleMap.removeAll()
+for device in self.devices {
+    if let pairPartnerUUID = pairPartners[device.uuid] {
+        if invisibleUUIDs.contains(pairPartnerUUID) {
+            satelliteToVisibleMap[pairPartnerUUID] = device.uuid
+        }
+    }
+}
+```
+
+**Potential Enhancement**: Expand to include group member → coordinator mapping:
+```swift
+// Map ALL group members to their coordinators
+for device in self.devices {
+    if let coordinatorUUID = device.groupCoordinatorUUID,
+       coordinatorUUID != device.uuid {
+        memberToCoordinatorMap[device.uuid] = coordinatorUUID
+    }
+}
+```
+
+## Debugging Event Subscriptions
+
+### Diagnostic Logging
+
+When troubleshooting event issues, log:
+
+1. **Subscription creation:**
+   ```swift
+   print("🎵 Subscribed to \(device.name) AVTransport")
+   print("   Device UUID: \(device.uuid)")
+   print("   SID: \(sid)")
+   print("   Callback URL: \(callbackURL)")
+   ```
+
+2. **Event arrival:**
+   ```swift
+   print("🔍 Transport event received:")
+   print("   Event UUID: \(deviceUUID)")
+   print("   State: \(state)")
+   print("   Mapped UUID: \(satelliteToVisibleMap[deviceUUID] ?? "none")")
+   ```
+
+3. **Card lookup:**
+   ```swift
+   print("   Card found: \(cardExists)")
+   print("   Device in cache: \(deviceInCache)")
+   ```
+
+### Common Issues
+
+**Symptom**: Events not arriving
+- Check firewall (allow inbound on callback port)
+- Verify callback URL uses correct local IP
+- Confirm subscription didn't expire (check timeout)
+
+**Symptom**: Events arrive but UI doesn't update
+- UUID mismatch between event and card identifier
+- NotificationCenter observer not registered
+- Card lookup failing (wrong identifier search)
+
+**Symptom**: Events arrive for some speakers but not others
+- Check which devices actually emit events (coordinator vs. member behavior)
+- Verify subscriptions created for all expected devices
+- Look for subscription errors in logs
+
+## References
+
+- **UPnP Device Architecture 1.0**: https://www.upnp.org/specs/arch/UPnPDA10_20000613.htm
+- **UPnP AVTransport Specification**: Open Connectivity Foundation
+- **SoCo Python Library**: https://github.com/SoCo/SoCo (reference implementation)
+- **Sonos API Documentation**: https://sonos.svrooij.io/ (unofficial)
+
+## Related Files
+
+- `UPnPEventListener.swift` - HTTP server and subscription lifecycle
+- `SonosController.swift:634-663` - Subscription initialization
+- `SonosController.swift:783-832` - Event processing
+- `MenuBarContentView.swift:180-207` - UI updates from events
+


### PR DESCRIPTION
## Problem

Transport state updates (play/pause) were not triggering UI updates for any speakers. The issue was blocking real-time feedback in the menu bar popover.

## Root Cause

Sonos sends AVTransport LastChange events with **HTML-encoded XML** rather than raw XML tags:
```xml
<LastChange>&lt;Event xmlns=&quot;...&quot;&gt;&lt;TransportState val=&quot;PLAYING&quot;/&gt;...
```

The parser was searching for `<TransportState` but couldn't find it because it was encoded as `&lt;TransportState`.

## Solution

1. **HTML entity decoding**: Added decoding before XML parsing (`&quot;`, `&lt;`, `&gt;`, `&amp;`)
2. **Concurrency fix**: Wrapped NotificationCenter.post in MainActor.run to prevent dispatch queue crashes
3. **UI overlapping fix**: Methods now update existing UI elements instead of creating duplicates

## Changes

- `UPnPEventListener.swift`: HTML entity decoding in `parseAndEmitTransportEvent()`
- `SonosController.swift`: MainActor wrapper for NotificationCenter, removed diagnostic logging
- `MenuBarContentView.swift`: Fixed metadata overlapping by reusing UI elements
- Added comprehensive UPnP/GENA documentation: `docs/sonos-api/upnp-events.md`
- Updated CHANGELOG.md and ROADMAP.md

## Testing

Manually tested with:
- ✅ All speakers receive real-time play/pause updates
- ✅ No crashes during transport state changes
- ✅ No overlapping metadata text
- ✅ Works with stereo pairs, groups, and ungrouped speakers

## Screenshots

See attached screenshots showing successful transport state updates without crashes or overlapping text.

Closes P0 bug documented in ROADMAP.md line 31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>