### PR TITLE
Feature: Intelligent audio source selection when grouping

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,8 @@ _When starting work on a task, add it here with your branch name and username to
 **Example format:**
 - **Task description** (branch: feature/task-name, @username)
 
+- **Intelligent audio source selection when grouping** (branch: feature/intelligent-coordinator-selection, @austinbjohnson)
+
 ---
 
 ## App Store Readiness

--- a/thoughts/shared/handoffs/general/2025-10-04_15-29-17_simplify-now-playing-ui.md
+++ b/thoughts/shared/handoffs/general/2025-10-04_15-29-17_simplify-now-playing-ui.md
@@ -1,0 +1,140 @@
+---
+date: 2025-10-04T15:29:17-07:00
+researcher: Claude
+git_commit: dd249a567bd39ad3948716212f4cad5971d291cb
+branch: feature/simplify-now-playing-ui
+repository: abj_volumeController
+topic: "UI Simplification - Consolidate Album Art Display"
+tags: [ui, ux, now-playing, album-art, cleanup, simplification]
+status: complete
+last_updated: 2025-10-04
+last_updated_by: Claude
+type: implementation_strategy
+---
+
+# Handoff: Simplify Now Playing UI - Album Art Consolidation
+
+## Task(s)
+
+### Completed ✅
+**Primary Goal**: Simplify the menu bar UI by consolidating album art display to only the now-playing section, removing it from individual speaker/group cards in the speaker list.
+
+**What was accomplished**:
+1. ✅ Resolved conflicts on PR #55 (Now Playing display and UI/UX improvements) - merged to main
+2. ✅ Created new branch `feature/simplify-now-playing-ui` 
+3. ✅ Removed album art from `createGroupCard()` - simplified layout to 38pt positioning
+4. ✅ Removed album art from `createSpeakerCard()` - removed all album art calls
+5. ✅ Deleted `addNowPlayingLabel()` helper method (94 lines)
+6. ✅ Deleted `addAlbumArtImage()` helper method (122 lines)
+7. ✅ Updated `updateCardWithNowPlaying()` to only manage source badges
+8. ✅ Created PR #57 with comprehensive description
+9. ✅ Resolved merge conflicts with main (PR #55 had merged with different PR numbers)
+10. ✅ PR #57 is now mergeable and ready for review
+
+**Result**: Album art now appears exclusively in the dedicated now-playing section (44x44pt) at the top of the popover. Speaker and group cards show only essential information: icon, name, checkbox, and source badge. Removed 272 lines of code.
+
+## Critical References
+
+- Base work: PR #55 (Now Playing display and UI/UX improvements) - merged to main
+- Planning document: `thoughts/shared/handoffs/general/2025-10-04_14-34-31_simplify-now-playing-ui.md` - original handoff outlining this work
+- Previous context: `thoughts/shared/handoffs/general/2025-10-04_13-35-00_ui-ux-improvements.md` - background on now-playing implementation
+
+## Recent Changes
+
+**Feature Implementation** (commit 6f4678b):
+- `SonosVolumeController/Sources/MenuBarContentView.swift:970-994` - Simplified `createGroupCard()`, removed album art logic, nameLabel always at 38pt
+- `SonosVolumeController/Sources/MenuBarContentView.swift:1200-1208` - Simplified `createSpeakerCard()`, removed album art calls
+- `SonosVolumeController/Sources/MenuBarContentView.swift:1425-1441` - Simplified `updateCardWithNowPlaying()`, only manages badges now
+- `SonosVolumeController/Sources/MenuBarContentView.swift` - Deleted lines 1443-1662 (addNowPlayingLabel and addAlbumArtImage methods)
+- `CHANGELOG.md:40` - Added UI simplification entry
+
+**Conflict Resolution** (commit dd249a5):
+- `CHANGELOG.md:11,40,49` - Updated PR numbers from #56 to #55 (merged version)
+- `SonosVolumeController/Sources/MenuBarContentView.swift` - Resolved conflicts favoring simplified version
+
+## Learnings
+
+### UI Architecture
+1. **Album art caching preserved**: The `SonosController.albumArtCache` (line 18) and `fetchAlbumArt()` method (lines 1631-1654) remain intact and functional - still used by the now-playing section
+2. **Source badges remain important**: Green/blue/teal colored dots provide at-a-glance visual feedback without cluttering the UI
+3. **Layout constraints simplified**: Group cards now consistently use 38pt leading (8 leading + 20 icon + 10 spacing) without conditional logic
+
+### Code Organization
+1. **Method deletion vs refactoring**: Removed methods entirely rather than refactoring to text-only, since the now-playing section provides all necessary context
+2. **Cache-based rendering**: The `nowPlayingCache` structure (line 72) remains the single source of truth for transport state and metadata
+
+### Build & Merge Process
+1. **PR numbering changed**: During development, PR #56 was referenced but merged as PR #55 to main
+2. **Conflict resolution pattern**: Main had merged PR #55, so conflicts needed to adopt #55 numbering while preserving #57 changes
+
+## Artifacts
+
+### Created Files
+- `thoughts/shared/handoffs/general/2025-10-04_15-29-17_simplify-now-playing-ui.md` - This handoff document
+
+### Modified Files
+- `SonosVolumeController/Sources/MenuBarContentView.swift` - Removed 272 lines, simplified card creation
+- `CHANGELOG.md` - Added UI simplification entry with PR #57 reference
+
+### Pull Requests
+- **PR #57**: https://github.com/austinbjohnson/sonos_volume_controller/pull/57
+  - Status: Open, mergeable, ready for review
+  - Title: "Feature: Simplify now-playing UI by consolidating album art"
+  - Branch: `feature/simplify-now-playing-ui`
+  - Commits: 3 (feature, CHANGELOG update, conflict resolution)
+
+## Action Items & Next Steps
+
+### For User Review
+1. **Review and merge PR #57** - UI simplification is complete and tested
+   - Verify album art appears only in now-playing section
+   - Check that speaker/group cards show clean layout
+   - Confirm source badges display correctly
+
+### After Merge
+2. **Manual testing recommended**:
+   - Test with multiple speakers playing different sources
+   - Verify switching between speakers updates now-playing correctly
+   - Check all source types: streaming, radio, line-in, TV, idle
+   - Confirm layout is cleaner without duplicate album art
+
+3. **Optional follow-up work** (from original handoff):
+   - Investigate if now-playing section updates consistently when switching speakers (user reported it sometimes doesn't update despite fixes)
+   - Consider if any additional UI polish is needed
+
+## Other Notes
+
+### Design Rationale
+The consolidation achieves five key benefits:
+1. **Cleaner UI** - Less visual clutter in speaker list
+2. **Better focus** - Album art in now-playing has more context
+3. **Performance** - Fewer image views to render and update
+4. **Mobile-friendly pattern** - Matches typical music app UX
+5. **Consistency** - One source of truth for "what's playing"
+
+### Code Locations
+**Now-Playing Section** (album art preserved):
+- `MenuBarContentView.swift:459-535` - `setupNowPlayingSection()` method
+- `MenuBarContentView.swift:537-694` - `updateNowPlayingDisplay()` method
+- `MenuBarContentView.swift:633-694` - Album art helper methods for now-playing
+
+**Speaker/Group Cards** (album art removed):
+- `MenuBarContentView.swift:907-997` - `createGroupCard()` - simplified
+- `MenuBarContentView.swift:1087-1237` - `createSpeakerCard()` - simplified
+- `MenuBarContentView.swift:1443-1505` - `addSourceBadge()` - preserved
+
+### Build Commands
+```bash
+cd SonosVolumeController
+swift build              # Verify compilation
+swift run                # Test locally
+./build-app.sh --install # Install to /Applications
+```
+
+### Branch Strategy
+- Branch: `feature/simplify-now-playing-ui`
+- Based on: `feature/playback-controls` (which had PR #55)
+- Conflicts resolved with: `main` (where PR #55 merged)
+- Ready to merge to: `main`
+
+


### PR DESCRIPTION
## Overview
Implements intelligent coordinator selection when grouping speakers based on playback state. The system now automatically chooses the playing device as coordinator, and only prompts users when multiple devices are playing different content.

## Changes

### Backend (SonosController.swift)
- **New CoordinatorSelection struct**: Returns analysis results including suggested coordinator, playing devices, and whether user input is required
- **New analyzeCoordinatorSelection() method**: Implements simplified priority model where PLAYING always beats PAUSED/STOPPED (regardless of source type)
- **Smart routing logic**:
  - 0 devices playing → automatic (first device, prefer non-stereo-pair)
  - 1 device playing → automatic (that device becomes coordinator)
  - 2+ devices playing → requires user choice

### UI (MenuBarContentView.swift)
- **Enhanced grouping flow**: groupSpeakers() now analyzes playback state before grouping
- **New showEnhancedCoordinatorSelectionDialog()**: Rich dialog showing now-playing information:
  - Track title, artist, and album for streaming content
  - Source type labels for non-streaming (Line-In, TV, Radio)
  - Clear button text: "Continue with [Device Name]"
  - Informative layout with emoji icons
- **Cleanup**: Removed showSourcePreservationDialog() (replaced by new simplified model)

## Priority Model (Simplified)

**PLAYING > PAUSED/STOPPED** (source type no longer matters)

This aligns with the Sonos physical button UX where actively playing audio takes precedence.

## User Experience

### Automatic Grouping (No Prompt)
- **Scenario 1**: Two idle speakers → Groups instantly
- **Scenario 2**: One playing + one idle → Groups instantly, playing device becomes coordinator

### User Choice (Enhanced Dialog)
- **Scenario 3**: Two speakers playing different content → Shows dialog with track/artist info for each device

## Testing Checklist

- [ ] **Two idle speakers** → Should group automatically (no prompt)
- [ ] **One playing + one idle** → Should group automatically (playing becomes coordinator)
- [ ] **Two speakers playing different songs** → Should show enhanced dialog with track info
- [ ] **Line-in + streaming playing** → Should show dialog with source type vs track info
- [ ] **Radio + streaming playing** → Should show dialog with both sources clearly labeled
- [ ] **Verify chosen coordinator preserves playback** after grouping
- [ ] **Cancel dialog** → Should return to normal state without grouping

## Manual Testing

To test locally:
```bash
cd SonosVolumeController
swift run
```

Or build and install:
```bash
./build-app.sh --install
```

## Related
- Closes ROADMAP item: **Intelligent audio source selection when grouping** (P1 Feature)
- Inspired by Sonos physical button UX behavior

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)  
Co-Authored-By: Claude <noreply@anthropic.com>

