### PR TITLE
Feature: Coordinator-aware transport routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed hotkeys not working in installed app - reverted to F11/F12 defaults, fixed CGEventFlags conversion, added network entitlements, improved permission flow with auto-restart (PR #22)
 
 ### Fixed
+- Transport controls now target the group coordinator even when a member is selected, keeping play/pause/skip state accurate.
 - Speaker and group name text truncation - fixed issue where long group names like "Bathroom + Bedroom" were being cut off in the middle (showing "athroom + Bedroom"). Applied explicit trailing constraints, changed truncation mode from middle to tail (ellipsis at end), added tooltips showing full names on hover. Applies to all cards: group cards, speaker cards, member cards, and now-playing labels (PR #55)
 - Transport state updates for all speakers - fixed critical bug where play/pause events weren't triggering UI updates. Root cause: Sonos sends AVTransport events with HTML-encoded XML (`&lt;TransportState&gt;`) rather than raw tags. Added HTML entity decoding before parsing. Also fixed concurrency crash by ensuring NotificationCenter posts happen on main thread via MainActor. All speakers now receive real-time play/pause UI updates (PR #53)
 - Now playing metadata overlapping text - fixed UI bug where track metadata would overlap instead of replacing when tracks changed. Methods now update existing UI elements instead of creating new ones on top of old ones (PR #53)

--- a/SonosVolumeController/Sources/SonosController.swift
+++ b/SonosVolumeController/Sources/SonosController.swift
@@ -1754,12 +1754,19 @@ actor SonosController {
     /// Get transport capabilities for the selected device
     /// Returns (canControl: Bool, supportsSkipping: Bool)
     nonisolated func getTransportCapabilities() -> (canControl: Bool, supportsSkipping: Bool) {
-        guard let device = _cachedSelectedDevice else {
+        guard let selectedDevice = _cachedSelectedDevice else {
             return (false, false)
         }
 
+        let transportDevice: SonosDevice
+        if let group = getCachedGroupForDevice(selectedDevice) {
+            transportDevice = group.coordinator
+        } else {
+            transportDevice = selectedDevice
+        }
+
         // Check if we have audio source info
-        let sourceType = device.audioSource ?? .idle
+        let sourceType = transportDevice.audioSource ?? .idle
         
         // Can control if not idle
         let canControl = sourceType != .idle


### PR DESCRIPTION
## Summary
- Resolve transport controls and playback state against the group coordinator when a member is selected.
- Update now-playing display and control availability based on the coordinator’s source.
- Keep selection labels unchanged while routing play/pause/skip to the correct target.

## Testing
- Not run (please run manual steps).

## Manual Test Plan
- Select a grouped member card and verify play/pause controls reflect the coordinator’s state.
- Use next/previous with a grouped member selected and confirm the coordinator advances.
- Confirm member volume sliders still adjust the individual speaker.

## Issues
- Closes #110