### PR TITLE
Chore: Menu bar cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-Core code lives in `SonosVolumeController/Sources`, with infrastructure services under `Infrastructure/`, input monitors in `VolumeKeyMonitor.swift` and `AudioDeviceMonitor.swift`, and UI surfaces in `MenuBarContentView.swift`, `MenuBarPopover.swift`, and `PreferencesWindow.swift`. Packaging assets and entitlements sit in `Resources/`. Docs such as `docs/sonos-api/` hold Sonos protocol notes; keep new research there for future contributors.
+Core code lives in `SonosVolumeController/Sources`, with infrastructure services under `Infrastructure/`, input monitors in `VolumeKeyMonitor.swift` and `AudioDeviceMonitor.swift`, and UI surfaces in `MenuBarContentView.swift`, `MenuBarMenu.swift`, and `PreferencesWindow.swift`. Packaging assets and entitlements sit in `Resources/`. Docs such as `docs/sonos-api/` hold Sonos protocol notes; keep new research there for future contributors.
 
 ## Build, Test, and Development Commands
 `swift run` from `SonosVolumeController/` provides the fastest feedback loop; run `pkill SonosVolumeController` first to avoid duplicate menu bar icons. `swift build -c release` validates optimized builds. Use `./build-app.sh` to bundle locally and `./build-app.sh --install` to copy into `/Applications` and relaunch the production build.

--- a/AI_DEV_GUIDE.md
+++ b/AI_DEV_GUIDE.md
@@ -147,7 +147,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 | `AudioDeviceMonitor.swift` | Tracks active audio output device |
 | `SonosController.swift` | Sonos device discovery and control (actor) |
 | `VolumeHUD.swift` | On-screen volume display (Liquid Glass HUD) |
-| `MenuBarContentView.swift` | Menu bar popover UI |
+| `MenuBarContentView.swift` | Menu bar menu UI |
 | `PreferencesWindow.swift` | Settings window |
 
 ### Infrastructure Layer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ gh pr create --title "Title" --body "Description"
 - **AudioDeviceMonitor.swift**: Tracks current audio output device
 - **SonosController.swift**: Sonos device discovery and control
 - **VolumeHUD.swift**: On-screen volume display (Liquid Glass HUD)
-- **MenuBarContentView.swift**: Menu bar popover UI
+- **MenuBarContentView.swift**: Menu bar menu UI
 - **PreferencesWindow.swift**: Settings window
 
 ### Important Patterns

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A native macOS menu bar app for controlling Sonos speakers with hotkeys. Control
 
 - 🎹 **Hotkey Control**: F11/F12 for volume control with visual HUD display
 - 🎯 **Smart Triggering**: Optionally activate only when specific audio device is selected (defaults to "Any Device")
-- 🖥️ **Menu Bar Integration**: Native macOS menu bar app with popover controls
+- 🖥️ **Menu Bar Integration**: Native macOS menu bar app with menu controls
 - 🔍 **Auto-Discovery**: Automatic Sonos speaker detection on local network
 - 🎛️ **Speaker Grouping**: Create, manage, and control speaker groups
 - 📊 **Hierarchical Group UI**: Expandable group cards to control individual speakers within groups

--- a/SonosVolumeController/Sources/MenuBarConstants.swift
+++ b/SonosVolumeController/Sources/MenuBarConstants.swift
@@ -1,5 +1,5 @@
 import AppKit
 
 enum MenuBarLayout {
-    static let popoverWidth: CGFloat = 420
+    static let menuWidth: CGFloat = 420
 }

--- a/SonosVolumeController/Sources/MenuBarContentView.swift
+++ b/SonosVolumeController/Sources/MenuBarContentView.swift
@@ -1,15 +1,15 @@
 import Cocoa
 
-// Custom view that enforces MenuBarLayout.popoverWidth for popover sizing
+// Custom view that enforces MenuBarLayout.menuWidth for menu sizing
 private class FixedWidthView: NSView {
     private var widthConstraint: NSLayoutConstraint?
 
     override func updateConstraints() {
         super.updateConstraints()
 
-        // Enforce popover width constraint
+        // Enforce menu width constraint
         if widthConstraint == nil {
-            let constraint = widthAnchor.constraint(equalToConstant: MenuBarLayout.popoverWidth)
+            let constraint = widthAnchor.constraint(equalToConstant: MenuBarLayout.menuWidth)
             constraint.priority = .required
             constraint.isActive = true
             widthConstraint = constraint
@@ -17,11 +17,11 @@ private class FixedWidthView: NSView {
     }
 
     override var fittingSize: NSSize {
-        return NSSize(width: MenuBarLayout.popoverWidth, height: super.fittingSize.height)
+        return NSSize(width: MenuBarLayout.menuWidth, height: super.fittingSize.height)
     }
 
     override var intrinsicContentSize: NSSize {
-        return NSSize(width: MenuBarLayout.popoverWidth, height: NSView.noIntrinsicMetric)
+        return NSSize(width: MenuBarLayout.menuWidth, height: NSView.noIntrinsicMetric)
     }
 }
 
@@ -99,12 +99,12 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
     }
 
     override func loadView() {
-        // Main container - width fixed at popoverWidth via custom fittingSize, height dynamic
-        containerView = FixedWidthView(frame: NSRect(x: 0, y: 0, width: MenuBarLayout.popoverWidth, height: 500))
+        // Main container - width fixed at menuWidth via custom fittingSize, height dynamic
+        containerView = FixedWidthView(frame: NSRect(x: 0, y: 0, width: MenuBarLayout.menuWidth, height: 500))
         self.view = containerView
 
         // Set preferred content size to prevent auto-sizing
-        self.preferredContentSize = NSSize(width: MenuBarLayout.popoverWidth, height: 500)
+        self.preferredContentSize = NSSize(width: MenuBarLayout.menuWidth, height: 500)
 
         // Single glass effect view
         glassView = NSGlassEffectView()
@@ -698,13 +698,13 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
     private func showNowPlayingSection() {
         nowPlayingContainer.isHidden = false
         nowPlayingHeightConstraint.constant = 64  // Album art (44pt) + padding
-        updatePopoverSize(animated: true, duration: 0.2)
+        updateMenuSize(animated: true, duration: 0.2)
     }
     
     private func hideNowPlayingSection() {
         nowPlayingContainer.isHidden = true
         nowPlayingHeightConstraint.constant = 0
-        updatePopoverSize(animated: true, duration: 0.2)
+        updateMenuSize(animated: true, duration: 0.2)
     }
     
     private func loadAlbumArt(url: String, sourceType: SonosController.AudioSourceType) {
@@ -1543,7 +1543,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
             scrollView.reflectScrolledClipView(scrollView.contentView)
         }
 
-        // Update popover size after initial populate
+        // Update menu size after initial populate
         // Force layout to complete before calculating heights
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
@@ -1559,7 +1559,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
                 scrollView.reflectScrolledClipView(scrollView.contentView)
             }
 
-            self.updatePopoverSize(animated: false)
+            self.updateMenuSize(animated: false)
             
             // Update now-playing display for selected device
             self.updateNowPlayingDisplay()
@@ -1595,8 +1595,8 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
                 for (uuid, state, sourceType, nowPlaying) in results {
                     self.updateCardWithNowPlaying(uuid: uuid, state: state, sourceType: sourceType, nowPlaying: nowPlaying, skipResize: true)
                 }
-                // Resize popover once after all updates
-                self.updatePopoverSize(animated: true, duration: 0.15)
+                // Resize menu once after all updates
+                self.updateMenuSize(animated: true, duration: 0.15)
             }
         }
     }
@@ -2334,7 +2334,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
 
         updateGroupActionsVisibility()
         populateSpeakers()
-        updatePopoverSize(animated: true, duration: 0.15)
+        updateMenuSize(animated: true, duration: 0.15)
     }
 
     private func updateGroupActionsVisibility() {
@@ -2845,17 +2845,17 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         return cardsHeight
     }
 
-    private func updatePopoverSize(animated: Bool = true, duration: TimeInterval = 0.25) {
+    private func updateMenuSize(animated: Bool = true, duration: TimeInterval = 0.25) {
         // Guard against being called before view is loaded
         guard scrollViewHeightConstraint != nil else {
-            print("⚠️ updatePopoverSize called before view loaded, skipping")
+            print("⚠️ updateMenuSize called before view loaded, skipping")
             return
         }
 
         let contentHeight = calculateContentHeight()
         
         // Calculate max scroll height based on screen size
-        // Reserve space for menu bar, popover margins, and other sections
+        // Reserve space for menu bar, menu margins, and other sections
         let screenHeight = NSScreen.main?.visibleFrame.height ?? 900
         let otherSectionsHeight: CGFloat = 450  // Approximate height of non-scrollable sections
         let maxScrollHeight = max(200, screenHeight - otherSectionsHeight)  // At least 200pt, typically 450-700pt
@@ -2863,7 +2863,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         let newScrollHeight = min(contentHeight, maxScrollHeight)
 
         #if DEBUG
-        print("🔍 [RESIZE] updatePopoverSize(animated: \(animated), duration: \(duration))")
+        print("🔍 [RESIZE] updateMenuSize(animated: \(animated), duration: \(duration))")
         print("🔍 [RESIZE] Content height: \(contentHeight), scroll height: \(newScrollHeight)")
         #endif
 
@@ -2887,7 +2887,7 @@ class MenuBarContentViewController: NSViewController, NSGestureRecognizerDelegat
         containerView.layoutSubtreeIfNeeded()
 
         let fittingHeight = max(containerView.fittingSize.height, 200)
-        let newSize = NSSize(width: MenuBarLayout.popoverWidth, height: fittingHeight)
+        let newSize = NSSize(width: MenuBarLayout.menuWidth, height: fittingHeight)
         self.preferredContentSize = newSize
 
         appDelegate?.menuBarMenu?.updateLayout()

--- a/SonosVolumeController/Sources/MenuBarMenu.swift
+++ b/SonosVolumeController/Sources/MenuBarMenu.swift
@@ -3,13 +3,11 @@ import Cocoa
 @available(macOS 26.0, *)
 @MainActor
 final class MenuBarMenu: NSObject, NSMenuDelegate {
-    private weak var appDelegate: AppDelegate?
     private let menu: NSMenu
     private let menuItem: NSMenuItem
     private let menuContentViewController: MenuBarContentViewController
 
     init(appDelegate: AppDelegate) {
-        self.appDelegate = appDelegate
         self.menu = NSMenu()
         self.menuItem = NSMenuItem()
         self.menuContentViewController = MenuBarContentViewController(appDelegate: appDelegate)
@@ -18,7 +16,7 @@ final class MenuBarMenu: NSObject, NSMenuDelegate {
 
         menu.autoenablesItems = false
         menu.delegate = self
-        menu.minimumWidth = MenuBarLayout.popoverWidth
+        menu.minimumWidth = MenuBarLayout.menuWidth
 
         menuItem.view = menuContentViewController.view
         menu.addItem(menuItem)
@@ -48,9 +46,9 @@ final class MenuBarMenu: NSObject, NSMenuDelegate {
         let fittingHeight = view.fittingSize.height
         let targetHeight = max(preferredHeight, fittingHeight, 200)
 
-        view.frame = NSRect(x: 0, y: 0, width: MenuBarLayout.popoverWidth, height: targetHeight)
+        view.frame = NSRect(x: 0, y: 0, width: MenuBarLayout.menuWidth, height: targetHeight)
         menuItem.view = view
-        menu.minimumWidth = MenuBarLayout.popoverWidth
+        menu.minimumWidth = MenuBarLayout.menuWidth
     }
 
     // MARK: - NSMenuDelegate

--- a/SonosVolumeController/Sources/main.swift
+++ b/SonosVolumeController/Sources/main.swift
@@ -141,7 +141,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                         // First launch - show menu to guide user to select a speaker
                         print("👋 First launch detected - showing onboarding menu")
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                            guard let button = self.statusItem.button else { return }
+                            guard self.statusItem.button != nil else { return }
                             self.menuBarMenu.show(from: self.statusItem)
                         }
                     }


### PR DESCRIPTION
## Summary
- rename popover sizing references to menu sizing and keep a single MenuBarLayout.menuWidth constant
- align menu sizing comments/labels and remove unused menu delegate state
- update docs to point at MenuBarMenu and menu terminology

## Testing
- not run (manual): 